### PR TITLE
feat: add surfpool and agave packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ jobs:
       - name: 🔍 detect changed packages
         id: changes
         run: |
-          LINUX_PACKAGES="cargo-interactive-update codex-cli cursor-cli google-chrome knope mdt pnpm-standalone racket-minimal"
-          MACOS_PACKAGES="cargo-interactive-update codex-cli cursor-cli google-chrome google-drive gpg-suite knope mdt nordvpn pnpm-standalone racket-minimal steam zoom"
+          LINUX_PACKAGES="agave cargo-interactive-update codex-cli cursor-cli google-chrome knope mdt pnpm-standalone racket-minimal surfpool"
+          MACOS_PACKAGES="agave cargo-interactive-update codex-cli cursor-cli google-chrome google-drive gpg-suite knope mdt nordvpn pnpm-standalone racket-minimal steam surfpool zoom"
 
           build_all=false
 

--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,7 @@
       overlays.default =
         final: _prev:
         {
+          agave = final.callPackage ./packages/agave/package.nix { };
           cargo-interactive-update = final.callPackage ./packages/cargo-interactive-update/package.nix { };
           codex-cli = final.callPackage ./packages/codex-cli/package.nix { };
           cursor-cli = final.callPackage ./packages/cursor-cli/package.nix { };
@@ -28,6 +29,7 @@
           pnpm-standalone = final.callPackage ./packages/pnpm-standalone/package.nix { };
           racket-minimal = final.callPackage ./packages/racket-minimal/package.nix { };
           steam = final.callPackage ./packages/steam/package.nix { };
+          surfpool = final.callPackage ./packages/surfpool/package.nix { };
           zoom = final.callPackage ./packages/zoom/package.nix { };
         };
     }
@@ -41,6 +43,7 @@
         lib = pkgs.lib;
 
         packages = {
+          agave = pkgs.callPackage ./packages/agave/package.nix { };
           cargo-interactive-update = pkgs.callPackage ./packages/cargo-interactive-update/package.nix { };
           codex-cli = pkgs.callPackage ./packages/codex-cli/package.nix { };
           cursor-cli = pkgs.callPackage ./packages/cursor-cli/package.nix { };
@@ -53,6 +56,7 @@
           pnpm-standalone = pkgs.callPackage ./packages/pnpm-standalone/package.nix { };
           racket-minimal = pkgs.callPackage ./packages/racket-minimal/package.nix { };
           steam = pkgs.callPackage ./packages/steam/package.nix { };
+          surfpool = pkgs.callPackage ./packages/surfpool/package.nix { };
           zoom = pkgs.callPackage ./packages/zoom/package.nix { };
         };
 

--- a/packages/agave/package.nix
+++ b/packages/agave/package.nix
@@ -1,0 +1,83 @@
+{
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  makeWrapper,
+  lib,
+  zlib,
+  openssl,
+  udev,
+}:
+
+let
+  version = "3.1.8";
+
+  platformSuffix =
+    {
+      "aarch64-darwin" = "aarch64-apple-darwin";
+      "x86_64-darwin" = "x86_64-apple-darwin";
+      "x86_64-linux" = "x86_64-unknown-linux-gnu";
+    }
+    .${stdenv.hostPlatform.system} or (throw "Unsupported platform: ${stdenv.hostPlatform.system}");
+
+  hashes = {
+    "aarch64-apple-darwin" = "sha256-1ybv59CQD8QpjWRNX8wIMYdH+cxzzFeaeN+fm/Hoa0g=";
+    "x86_64-apple-darwin" = "sha256-la+UuQwGtJtzGcONzB4ei6AXWXysscLqwxYoo0/tmuU=";
+    "x86_64-unknown-linux-gnu" = "sha256-6VG7gSfFdGC8PryhZxlS6bFk4knXE/zr4sEl9wuHkeg=";
+  };
+in
+stdenv.mkDerivation {
+  pname = "agave";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://github.com/anza-xyz/agave/releases/download/v${version}/solana-release-${platformSuffix}.tar.bz2";
+    sha256 = hashes.${platformSuffix} or lib.fakeSha256;
+  };
+
+  dontBuild = true;
+  dontStrip = stdenv.isDarwin;
+
+  nativeBuildInputs =
+    lib.optionals stdenv.isLinux [
+      autoPatchelfHook
+      makeWrapper
+    ];
+
+  buildInputs = lib.optionals stdenv.isLinux [
+    stdenv.cc.cc.lib
+    zlib
+    openssl
+    udev
+  ];
+
+  sourceRoot = "solana-release";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    find bin -maxdepth 1 -type f -exec cp {} $out/bin/ \;
+    chmod +x $out/bin/*
+
+    # Include the platform tools SDK for cargo-build-sbf / cargo-test-sbf
+    if [ -d bin/platform-tools-sdk ]; then
+      mkdir -p $out/lib
+      cp -r bin/platform-tools-sdk $out/lib/
+    fi
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Solana validator client and CLI toolchain by Anza";
+    homepage = "https://github.com/anza-xyz/agave";
+    license = licenses.asl20;
+    platforms = [
+      "x86_64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+    mainProgram = "solana";
+  };
+}

--- a/packages/surfpool/package.nix
+++ b/packages/surfpool/package.nix
@@ -1,0 +1,63 @@
+{
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  lib,
+}:
+
+let
+  version = "1.0.1";
+
+  platformSuffix =
+    {
+      "aarch64-darwin" = "darwin-arm64";
+      "x86_64-darwin" = "darwin-x64";
+      "x86_64-linux" = "linux-x64";
+    }
+    .${stdenv.hostPlatform.system} or (throw "Unsupported platform: ${stdenv.hostPlatform.system}");
+
+  hashes = {
+    "darwin-arm64" = "sha256-UV7UQ8nAYeCNd3MuhL5FlmiogFAIXEGaC9my1KDIfiU=";
+    "darwin-x64" = "sha256-FuZ1z/ObZ+jsqb60TsA7lNasfUnibxtZ1LRtYyRUF1I=";
+    "linux-x64" = "sha256-deBY10j1L2ri4sZagBYuZMKUyOAr5RHPq0IjGHHjMtw=";
+  };
+in
+stdenv.mkDerivation {
+  pname = "surfpool";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://github.com/txtx/surfpool/releases/download/v${version}/surfpool-${platformSuffix}.tar.gz";
+    sha256 = hashes.${platformSuffix} or lib.fakeSha256;
+  };
+
+  dontBuild = true;
+  dontStrip = stdenv.isDarwin;
+
+  nativeBuildInputs = lib.optionals stdenv.isLinux [ autoPatchelfHook ];
+  buildInputs = lib.optionals stdenv.isLinux [ stdenv.cc.cc.lib ];
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp surfpool $out/bin/surfpool
+    chmod +x $out/bin/surfpool
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A drop-in replacement for solana-test-validator with mainnet state simulation";
+    homepage = "https://github.com/txtx/surfpool";
+    license = licenses.asl20;
+    platforms = [
+      "x86_64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+    mainProgram = "surfpool";
+  };
+}


### PR DESCRIPTION
## Summary
- Add **surfpool** v1.0.1 — a drop-in replacement for `solana-test-validator` with mainnet state simulation, IDL-to-SQL bridge, and developer cheatcodes
- Add **agave** v3.1.8 — the Solana validator client and CLI toolchain by Anza, installed from prebuilt release binaries

### Agave binaries included

| Binary | Description |
|---|---|
| `solana` | Primary Solana CLI for wallet management, transactions, staking, and program deployment |
| `solana-keygen` | Cryptographic keypair generation and management |
| `solana-test-validator` | Local test validator for development and testing |
| `agave-install` | Toolchain installer and self-updating package manager |
| `agave-install-init` | Bootstrapper for initializing the Agave toolchain |
| `agave-ledger-tool` | Ledger management, verification, snapshot creation, and analysis |
| `cargo-build-sbf` | Compile Solana on-chain programs using the SBF SDK (`cargo build-sbf`) |
| `cargo-test-sbf` | Test Solana on-chain programs (`cargo test-sbf`) |
| `solana-stake-accounts` | Manage derived stake accounts in batch |
| `solana-tokens` | Token distribution and balance management |
| `spl-token` | SPL Token CLI for creating mints, transferring, and managing token accounts |

## Test plan
- [ ] `validate` job passes (`nix flake show`)
- [ ] `surfpool` builds on all platforms (x86_64-linux, x86_64-darwin, aarch64-darwin)
- [ ] `agave` builds on all platforms (x86_64-linux, x86_64-darwin, aarch64-darwin)