### PR TITLE
feat(codexbar): add CodexBar macOS menu bar app package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -19,6 +19,7 @@
           agave = final.callPackage ./packages/agave/package.nix { };
           cargo-interactive-update = final.callPackage ./packages/cargo-interactive-update/package.nix { };
           codex-cli = final.callPackage ./packages/codex-cli/package.nix { };
+          codexbar = final.callPackage ./packages/codexbar/package.nix { };
           cursor-cli = final.callPackage ./packages/cursor-cli/package.nix { };
           google-chrome = final.callPackage ./packages/google-chrome/package.nix { };
           google-drive = final.callPackage ./packages/google-drive/package.nix { };
@@ -47,6 +48,7 @@
           agave = pkgs.callPackage ./packages/agave/package.nix { };
           cargo-interactive-update = pkgs.callPackage ./packages/cargo-interactive-update/package.nix { };
           codex-cli = pkgs.callPackage ./packages/codex-cli/package.nix { };
+          codexbar = pkgs.callPackage ./packages/codexbar/package.nix { };
           cursor-cli = pkgs.callPackage ./packages/cursor-cli/package.nix { };
           google-chrome = pkgs.callPackage ./packages/google-chrome/package.nix { };
           google-drive = pkgs.callPackage ./packages/google-drive/package.nix { };

--- a/packages/codexbar/package.nix
+++ b/packages/codexbar/package.nix
@@ -1,0 +1,46 @@
+{
+  stdenv,
+  fetchurl,
+  unzip,
+  lib,
+}:
+
+stdenv.mkDerivation {
+  pname = "codexbar";
+  version = "0.17.0";
+
+  src = fetchurl {
+    url = "https://github.com/steipete/CodexBar/releases/download/v0.17.0/CodexBar-0.17.0.zip";
+    hash = "sha256-LD86SQCPLi/yZOSjatAntcFA1hwzGsLnrOLB/5sMadw=";
+  };
+
+  nativeBuildInputs = [ unzip ];
+  sourceRoot = ".";
+  dontPatch = true;
+  dontConfigure = true;
+  dontBuild = true;
+  dontFixup = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/Applications
+    find . -name "*.app" -maxdepth 2 -type d -not -path "*/.app/*" | while IFS= read -r app; do
+      cp -r "$app" $out/Applications/
+    done
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "macOS menu bar app showing AI coding tool usage and limits";
+    homepage = "https://codexbar.app";
+    license = licenses.mit;
+    platforms = [
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+    maintainers = [ ];
+    sourceProvenance = [ sourceTypes.binaryNativeCode ];
+  };
+}


### PR DESCRIPTION
## Summary
- Add [CodexBar](https://github.com/steipete/CodexBar) v0.17.0 as a new macOS-only package
- CodexBar is a menu bar app that displays usage statistics and limits for AI coding tools (Claude Code, Codex, Cursor, Gemini, Copilot, and more)
- Installs `CodexBar.app` to `$out/Applications` for both `x86_64-darwin` and `aarch64-darwin`

## Test plan
- [x] `nix build .#codexbar` succeeds
- [x] `CodexBar.app` is present in `result/Applications/`
- [ ] CI passes on macOS runners