### PR TITLE
feat: add meta.tags to all packages for categorization

### DIFF
--- a/packages/agave/package.nix
+++ b/packages/agave/package.nix
@@ -38,11 +38,10 @@ stdenv.mkDerivation {
   dontBuild = true;
   dontStrip = stdenv.isDarwin;
 
-  nativeBuildInputs =
-    lib.optionals stdenv.isLinux [
-      autoPatchelfHook
-      makeWrapper
-    ];
+  nativeBuildInputs = lib.optionals stdenv.isLinux [
+    autoPatchelfHook
+    makeWrapper
+  ];
 
   buildInputs = lib.optionals stdenv.isLinux [
     stdenv.cc.cc.lib
@@ -79,5 +78,10 @@ stdenv.mkDerivation {
       "aarch64-darwin"
     ];
     mainProgram = "solana";
+    tags = [
+      "cli"
+      "dev-tool"
+      "solana"
+    ];
   };
 }

--- a/packages/cargo-interactive-update/package.nix
+++ b/packages/cargo-interactive-update/package.nix
@@ -29,5 +29,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/benjeau/cargo-interactive-update";
     license = lib.licenses.mit;
     mainProgram = "cargo-interactive-update";
+    tags = [
+      "cli"
+      "dev-tool"
+    ];
   };
 })

--- a/packages/codex-cli/package.nix
+++ b/packages/codex-cli/package.nix
@@ -64,5 +64,10 @@ stdenv.mkDerivation {
     ];
     maintainers = [ ];
     mainProgram = "codex";
+    tags = [
+      "cli"
+      "dev-tool"
+      "ai"
+    ];
   };
 }

--- a/packages/codexbar/package.nix
+++ b/packages/codexbar/package.nix
@@ -42,5 +42,11 @@ stdenv.mkDerivation {
     ];
     maintainers = [ ];
     sourceProvenance = [ sourceTypes.binaryNativeCode ];
+    tags = [
+      "gui"
+      "macos-app"
+      "dev-tool"
+      "ai"
+    ];
   };
 }

--- a/packages/cursor-cli/package.nix
+++ b/packages/cursor-cli/package.nix
@@ -68,5 +68,10 @@ stdenv.mkDerivation {
     ];
     maintainers = [ ];
     mainProgram = "cursor-agent";
+    tags = [
+      "cli"
+      "dev-tool"
+      "ai"
+    ];
   };
 }

--- a/packages/google-chrome/package.nix
+++ b/packages/google-chrome/package.nix
@@ -182,5 +182,10 @@ stdenv.mkDerivation {
     ];
     maintainers = [ ];
     sourceProvenance = [ sourceTypes.binaryNativeCode ];
+    tags = [
+      "gui"
+      "macos-app"
+      "browser"
+    ];
   };
 }

--- a/packages/google-drive/package.nix
+++ b/packages/google-drive/package.nix
@@ -44,5 +44,9 @@ stdenv.mkDerivation {
     ];
     maintainers = [ ];
     sourceProvenance = [ sourceTypes.binaryNativeCode ];
+    tags = [
+      "gui"
+      "macos-app"
+    ];
   };
 }

--- a/packages/gpg-suite/package.nix
+++ b/packages/gpg-suite/package.nix
@@ -47,5 +47,10 @@ stdenv.mkDerivation {
     ];
     maintainers = [ ];
     sourceProvenance = [ sourceTypes.binaryNativeCode ];
+    tags = [
+      "gui"
+      "macos-app"
+      "security"
+    ];
   };
 }

--- a/packages/knope/package.nix
+++ b/packages/knope/package.nix
@@ -39,5 +39,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://knope.tech";
     license = lib.licenses.mit;
     mainProgram = "knope";
+    tags = [
+      "cli"
+      "dev-tool"
+    ];
   };
 })

--- a/packages/mdt/package.nix
+++ b/packages/mdt/package.nix
@@ -26,5 +26,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/ifiokjr/mdt";
     license = lib.licenses.unlicense;
     mainProgram = "mdt";
+    tags = [
+      "cli"
+      "dev-tool"
+    ];
   };
 })

--- a/packages/nordvpn/package.nix
+++ b/packages/nordvpn/package.nix
@@ -45,5 +45,10 @@ stdenv.mkDerivation {
     ];
     maintainers = [ ];
     sourceProvenance = [ sourceTypes.binaryNativeCode ];
+    tags = [
+      "gui"
+      "macos-app"
+      "security"
+    ];
   };
 }

--- a/packages/pina/package.nix
+++ b/packages/pina/package.nix
@@ -26,5 +26,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://pina.rs";
     license = lib.licenses.asl20;
     mainProgram = "pina";
+    tags = [
+      "cli"
+      "dev-tool"
+      "solana"
+    ];
   };
 })

--- a/packages/pnpm-standalone/package.nix
+++ b/packages/pnpm-standalone/package.nix
@@ -125,5 +125,10 @@ stdenv.mkDerivation {
     ];
     maintainers = [ ];
     mainProgram = "pnpm";
+    tags = [
+      "cli"
+      "dev-tool"
+      "package-manager"
+    ];
   };
 }

--- a/packages/racket-minimal/package.nix
+++ b/packages/racket-minimal/package.nix
@@ -76,5 +76,9 @@ stdenv.mkDerivation {
       "aarch64-linux"
     ];
     mainProgram = "racket";
+    tags = [
+      "cli"
+      "dev-tool"
+    ];
   };
 }

--- a/packages/steam/package.nix
+++ b/packages/steam/package.nix
@@ -40,5 +40,10 @@ stdenv.mkDerivation {
     ];
     maintainers = [ ];
     sourceProvenance = [ sourceTypes.binaryNativeCode ];
+    tags = [
+      "gui"
+      "macos-app"
+      "gaming"
+    ];
   };
 }

--- a/packages/surfpool/package.nix
+++ b/packages/surfpool/package.nix
@@ -59,5 +59,10 @@ stdenv.mkDerivation {
       "aarch64-darwin"
     ];
     mainProgram = "surfpool";
+    tags = [
+      "cli"
+      "dev-tool"
+      "solana"
+    ];
   };
 }

--- a/packages/zoom/package.nix
+++ b/packages/zoom/package.nix
@@ -53,5 +53,10 @@ stdenv.mkDerivation {
     ];
     maintainers = [ ];
     sourceProvenance = [ sourceTypes.binaryNativeCode ];
+    tags = [
+      "gui"
+      "macos-app"
+      "communication"
+    ];
   };
 }


### PR DESCRIPTION
## Summary
- Add `meta.tags` to all 17 packages for lightweight categorization and filtering
- Tags vocabulary: `gui`, `cli`, `macos-app`, `dev-tool`, `ai`, `solana`, `browser`, `communication`, `security`, `gaming`, `package-manager`
- Verified with `nix flake show` and `nix eval` — no errors

## Test plan
- [x] `nix flake show` succeeds without errors
- [x] `nix eval .#codexbar.meta.tags` returns `[ "gui" "macos-app" "dev-tool" "ai" ]`
- [x] Spot-checked multiple packages (agave, pnpm-standalone, zoom)