### PR TITLE
chore: add dprint lint job to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,24 @@ jobs:
       - name: 🔍 validate flake
         run: nix flake show
 
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📥 checkout repository
+        uses: actions/checkout@v4
+
+      - name: 🔧 install nix
+        uses: DeterminateSystems/nix-installer-action@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 🔧 set up nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
+
+      - name: 🔍 lint
+        run: nix shell nixpkgs#dprint nixpkgs#nixfmt-rfc-style nixpkgs#shfmt -c dprint check
+
   test-update-script:
     name: "test update script (${{ matrix.os }})"
     runs-on: ${{ matrix.os }}

--- a/dprint.json
+++ b/dprint.json
@@ -1,0 +1,19 @@
+{
+  "indentWidth": 2,
+  "useTabs": true,
+  "exec": {
+    "commands": [
+      { "command": "nixfmt", "exts": ["nix"] },
+      {
+        "command": "shfmt --filename {{file_path}} -i 0",
+        "exts": ["sh", "bash"]
+      }
+    ]
+  },
+  "markdown": { "textWrap": "never" },
+  "excludes": ["result", ".direnv/**", ".devenv/**", "flake.lock"],
+  "plugins": [
+    "https://plugins.dprint.dev/markdown-0.20.0.wasm",
+    "https://plugins.dprint.dev/exec-0.6.0.json@a054130d458f124f9b5c91484833828950723a5af3f8ff2bd1523bd47b83b364"
+  ]
+}

--- a/flake.nix
+++ b/flake.nix
@@ -13,27 +13,25 @@
       flake-utils,
     }:
     {
-      overlays.default =
-        final: _prev:
-        {
-          agave = final.callPackage ./packages/agave/package.nix { };
-          cargo-interactive-update = final.callPackage ./packages/cargo-interactive-update/package.nix { };
-          codex-cli = final.callPackage ./packages/codex-cli/package.nix { };
-          codexbar = final.callPackage ./packages/codexbar/package.nix { };
-          cursor-cli = final.callPackage ./packages/cursor-cli/package.nix { };
-          google-chrome = final.callPackage ./packages/google-chrome/package.nix { };
-          google-drive = final.callPackage ./packages/google-drive/package.nix { };
-          gpg-suite = final.callPackage ./packages/gpg-suite/package.nix { };
-          knope = final.callPackage ./packages/knope/package.nix { };
-          mdt = final.callPackage ./packages/mdt/package.nix { };
-          nordvpn = final.callPackage ./packages/nordvpn/package.nix { };
-          pina = final.callPackage ./packages/pina/package.nix { };
-          pnpm-standalone = final.callPackage ./packages/pnpm-standalone/package.nix { };
-          racket-minimal = final.callPackage ./packages/racket-minimal/package.nix { };
-          steam = final.callPackage ./packages/steam/package.nix { };
-          surfpool = final.callPackage ./packages/surfpool/package.nix { };
-          zoom = final.callPackage ./packages/zoom/package.nix { };
-        };
+      overlays.default = final: _prev: {
+        agave = final.callPackage ./packages/agave/package.nix { };
+        cargo-interactive-update = final.callPackage ./packages/cargo-interactive-update/package.nix { };
+        codex-cli = final.callPackage ./packages/codex-cli/package.nix { };
+        codexbar = final.callPackage ./packages/codexbar/package.nix { };
+        cursor-cli = final.callPackage ./packages/cursor-cli/package.nix { };
+        google-chrome = final.callPackage ./packages/google-chrome/package.nix { };
+        google-drive = final.callPackage ./packages/google-drive/package.nix { };
+        gpg-suite = final.callPackage ./packages/gpg-suite/package.nix { };
+        knope = final.callPackage ./packages/knope/package.nix { };
+        mdt = final.callPackage ./packages/mdt/package.nix { };
+        nordvpn = final.callPackage ./packages/nordvpn/package.nix { };
+        pina = final.callPackage ./packages/pina/package.nix { };
+        pnpm-standalone = final.callPackage ./packages/pnpm-standalone/package.nix { };
+        racket-minimal = final.callPackage ./packages/racket-minimal/package.nix { };
+        steam = final.callPackage ./packages/steam/package.nix { };
+        surfpool = final.callPackage ./packages/surfpool/package.nix { };
+        zoom = final.callPackage ./packages/zoom/package.nix { };
+      };
     }
     // flake-utils.lib.eachDefaultSystem (
       system:

--- a/packages/agave/package.nix
+++ b/packages/agave/package.nix
@@ -38,11 +38,10 @@ stdenv.mkDerivation {
   dontBuild = true;
   dontStrip = stdenv.isDarwin;
 
-  nativeBuildInputs =
-    lib.optionals stdenv.isLinux [
-      autoPatchelfHook
-      makeWrapper
-    ];
+  nativeBuildInputs = lib.optionals stdenv.isLinux [
+    autoPatchelfHook
+    makeWrapper
+  ];
 
   buildInputs = lib.optionals stdenv.isLinux [
     stdenv.cc.cc.lib

--- a/readme.md
+++ b/readme.md
@@ -4,20 +4,20 @@ Additional Nix packages not yet available in [nixpkgs](https://github.com/NixOS/
 
 ## packages
 
-| Package | Version | Platforms | Description |
-|---------|---------|-----------|-------------|
-| [codex-cli](#codex-cli) | 0.104.0 | linux, macos | OpenAI Codex CLI - AI coding assistant for the terminal |
-| [cursor-cli](#cursor-cli) | 2026.02.13 | linux, macos | Cursor AI CLI agent for terminal-based development |
-| [google-chrome](#google-chrome) | latest | linux (x64), macos | Google Chrome web browser |
-| [google-drive](#google-drive) | latest | macos | Google Drive desktop client for macOS |
-| [gpg-suite](#gpg-suite) | 2023.3 | macos | GPG Suite - encryption, signing, and key management |
-| [knope](#knope) | 0.22.3 | linux, macos | Automate common development tasks (changelogs, releases, versioning) |
-| [mdt](#mdt) | 0.4.1 | linux, macos | Update markdown content anywhere using comments as template tags |
-| [nordvpn](#nordvpn) | 9.14.0 | macos | NordVPN macOS client |
-| [pnpm-standalone](#pnpm-standalone) | 10.30.2 | linux, macos | Fast, disk-space efficient package manager (no Node.js dependency) |
-| [racket-minimal](#racket-minimal) | 9.1 | linux, macos | Racket programming language (minimal distribution, pre-built) |
-| [steam](#steam) | 4.0 | macos | Steam video game digital distribution service |
-| [zoom](#zoom) | 6.7.6 | macos | Zoom video conferencing client |
+| Package                             | Version    | Platforms          | Description                                                          |
+| ----------------------------------- | ---------- | ------------------ | -------------------------------------------------------------------- |
+| [codex-cli](#codex-cli)             | 0.104.0    | linux, macos       | OpenAI Codex CLI - AI coding assistant for the terminal              |
+| [cursor-cli](#cursor-cli)           | 2026.02.13 | linux, macos       | Cursor AI CLI agent for terminal-based development                   |
+| [google-chrome](#google-chrome)     | latest     | linux (x64), macos | Google Chrome web browser                                            |
+| [google-drive](#google-drive)       | latest     | macos              | Google Drive desktop client for macOS                                |
+| [gpg-suite](#gpg-suite)             | 2023.3     | macos              | GPG Suite - encryption, signing, and key management                  |
+| [knope](#knope)                     | 0.22.3     | linux, macos       | Automate common development tasks (changelogs, releases, versioning) |
+| [mdt](#mdt)                         | 0.4.1      | linux, macos       | Update markdown content anywhere using comments as template tags     |
+| [nordvpn](#nordvpn)                 | 9.14.0     | macos              | NordVPN macOS client                                                 |
+| [pnpm-standalone](#pnpm-standalone) | 10.30.2    | linux, macos       | Fast, disk-space efficient package manager (no Node.js dependency)   |
+| [racket-minimal](#racket-minimal)   | 9.1        | linux, macos       | Racket programming language (minimal distribution, pre-built)        |
+| [steam](#steam)                     | 4.0        | macos              | Steam video game digital distribution service                        |
+| [zoom](#zoom)                       | 6.7.6      | macos              | Zoom video conferencing client                                       |
 
 ## usage
 
@@ -298,6 +298,7 @@ Run the repo updater to check every package for new upstream releases and refres
 ```
 
 The script updates:
+
 - GitHub release packages (version + platform hashes)
 - Homebrew-cask packages (`gpg-suite`, `nordvpn`, `zoom`)
 - Rolling URL packages (`google-chrome`, `google-drive`, `steam`)


### PR DESCRIPTION
## Summary
- Add `dprint.json` config with nixfmt (`.nix`), shfmt (`.sh`/`.bash`), and markdown formatting
- Add `lint` job to CI workflow that runs `dprint check` on every push/PR
- Format existing `.nix` and `.md` files so the lint check passes immediately

## Test plan
- [ ] Verify `dprint check` passes locally
- [ ] Verify the new `lint` CI job runs and passes
- [ ] Verify existing CI jobs (validate, test-update-script, builds) are unaffected