### PR TITLE
fix(pnpm-standalone): handle unset HOME in pnpm-activate-env

### DIFF
--- a/packages/pnpm-standalone/package.nix
+++ b/packages/pnpm-standalone/package.nix
@@ -143,6 +143,21 @@ stdenv.mkDerivation {
     EOF
         chmod +x "$FAKE_PNPM"
 
+        mkdir -p "$TEST_ROOT/home-fallback/ws/packages/app"
+        cat > "$TEST_ROOT/home-fallback/ws/pnpm-workspace.yaml" <<'EOF'
+    useNodeVersion: "20.11.1"
+    EOF
+
+        (
+          cd "$TEST_ROOT/home-fallback/ws/packages/app"
+          export PNPM_ACTIVATE_PNPM_BIN="$FAKE_PNPM"
+          export TEST_PNPM_HOME TEST_LOG
+          export PNPM_HOME="$TEST_PNPM_HOME"
+          unset HOME
+          EXPORTS="$($out/bin/pnpm-activate-env)"
+          test -n "$EXPORTS"
+        )
+
         mkdir -p "$TEST_ROOT/no-workspace"
         (
           cd "$TEST_ROOT/no-workspace"

--- a/packages/pnpm-standalone/pnpm-activate-env.sh
+++ b/packages/pnpm-standalone/pnpm-activate-env.sh
@@ -127,9 +127,32 @@ resolve_pnpm_bin() {
 	return 1
 }
 
+resolve_home_dir() {
+	local user=""
+	local home_dir=""
+
+	if [ -n "${HOME:-}" ]; then
+		printf '%s\n' "$HOME"
+		return 0
+	fi
+
+	user="$(id -un 2>/dev/null || true)"
+	if [ -n "$user" ]; then
+		home_dir="$(eval printf '%s' "~$user" 2>/dev/null || true)"
+		if [ -n "$home_dir" ] && [ "$home_dir" != "~$user" ]; then
+			printf '%s\n' "$home_dir"
+			return 0
+		fi
+	fi
+
+	echo "pnpm-activate-env: could not determine home directory; set HOME or PNPM_HOME" >&2
+	return 1
+}
+
 resolve_pnpm_home() {
 	local pnpm_bin="$1"
 	local global_bin=""
+	local home_dir=""
 
 	if [ -n "${PNPM_HOME:-}" ]; then
 		printf '%s\n' "$PNPM_HOME"
@@ -144,12 +167,14 @@ resolve_pnpm_home() {
 		return 0
 	fi
 
+	home_dir="$(resolve_home_dir)"
+
 	case "$(uname -s)" in
 	Darwin)
-		printf '%s\n' "${HOME}/Library/pnpm"
+		printf '%s\n' "${home_dir}/Library/pnpm"
 		;;
 	*)
-		printf '%s\n' "${HOME}/.local/share/pnpm"
+		printf '%s\n' "${home_dir}/.local/share/pnpm"
 		;;
 	esac
 }


### PR DESCRIPTION
## Summary
- handle unset `HOME` safely in `pnpm-activate-env`
- fall back to resolving the current user home directory when needed
- add an install check covering execution with `HOME` unset

## Testing
- nix build .#pnpm-standalone --no-link -L

Fixes the GitHub Actions failure seen in pina when `pnpm-activate-env` runs with `HOME` unset.