### PR TITLE
fix(pnpm-standalone): export PNPM_HOME during activation

### DIFF
--- a/packages/pnpm-standalone/package.nix
+++ b/packages/pnpm-standalone/package.nix
@@ -124,16 +124,18 @@ stdenv.mkDerivation {
     cat >> "$FAKE_PNPM" <<'EOF'
     set -eu
 
+    effective_pnpm_home="''${PNPM_HOME:-''${TEST_PNPM_HOME:?}}"
+
     case "''${1-} ''${2-} ''${3-}" in
       "bin -g ")
-        printf '%s\n' "''${TEST_PNPM_HOME:?}"
+        printf '%s\n' "$effective_pnpm_home"
         ;;
       "env add --global")
         version="''${4:?missing version}"
         printf 'env add %s\n' "$version" >> "''${TEST_LOG:?}"
-        mkdir -p "''${TEST_PNPM_HOME:?}/nodejs/$version/bin"
-        : > "''${TEST_PNPM_HOME:?}/nodejs/$version/bin/node"
-        chmod +x "''${TEST_PNPM_HOME:?}/nodejs/$version/bin/node"
+        mkdir -p "$effective_pnpm_home/nodejs/$version/bin"
+        : > "$effective_pnpm_home/nodejs/$version/bin/node"
+        chmod +x "$effective_pnpm_home/nodejs/$version/bin/node"
         ;;
       *)
         printf 'unexpected fake pnpm args: %s\n' "$*" >&2
@@ -143,19 +145,20 @@ stdenv.mkDerivation {
     EOF
         chmod +x "$FAKE_PNPM"
 
-        mkdir -p "$TEST_ROOT/home-fallback/ws/packages/app"
-        cat > "$TEST_ROOT/home-fallback/ws/pnpm-workspace.yaml" <<'EOF'
+        mkdir -p "$TEST_ROOT/unset-home/ws/packages/app"
+        cat > "$TEST_ROOT/unset-home/ws/pnpm-workspace.yaml" <<'EOF'
     useNodeVersion: "20.11.1"
     EOF
 
         (
-          cd "$TEST_ROOT/home-fallback/ws/packages/app"
+          cd "$TEST_ROOT/unset-home/ws/packages/app"
           export PNPM_ACTIVATE_PNPM_BIN="$FAKE_PNPM"
           export TEST_PNPM_HOME TEST_LOG
-          export PNPM_HOME="$TEST_PNPM_HOME"
-          unset HOME
+          unset HOME PNPM_HOME
           EXPORTS="$($out/bin/pnpm-activate-env)"
           test -n "$EXPORTS"
+          eval "$EXPORTS"
+          test "$PNPM_HOME" = "$TEST_PNPM_HOME"
         )
 
         mkdir -p "$TEST_ROOT/no-workspace"

--- a/packages/pnpm-standalone/pnpm-activate-env.sh
+++ b/packages/pnpm-standalone/pnpm-activate-env.sh
@@ -180,23 +180,39 @@ resolve_pnpm_home() {
 }
 
 emit_export_script() {
-	local node_bin="$1"
-	local quoted
+	local pnpm_home="$1"
+	local node_bin="$2"
+	local quoted_pnpm_home
+	local quoted_node_bin
 
-	quoted="$(shell_quote "$node_bin")"
+	quoted_pnpm_home="$(shell_quote "$pnpm_home")"
+	quoted_node_bin="$(shell_quote "$node_bin")"
 
-	printf '__pnpm_activate_node_bin=%s\n' "$quoted"
+	printf '__pnpm_activate_pnpm_home=%s\n' "$quoted_pnpm_home"
+	printf '__pnpm_activate_node_bin=%s\n' "$quoted_node_bin"
 	cat <<'EOF'
+export PNPM_HOME="${__pnpm_activate_pnpm_home}"
+case ":$PATH:" in
+  *":${__pnpm_activate_pnpm_home}:"*) ;;
+  *) export PATH="${__pnpm_activate_pnpm_home}:$PATH" ;;
+esac
 case ":$PATH:" in
   *":${__pnpm_activate_node_bin}:"*) ;;
   *) export PATH="${__pnpm_activate_node_bin}:$PATH" ;;
 esac
-unset __pnpm_activate_node_bin
+unset __pnpm_activate_pnpm_home __pnpm_activate_node_bin
 EOF
 }
 
 apply_path() {
-	local node_bin="$1"
+	local pnpm_home="$1"
+	local node_bin="$2"
+
+	export PNPM_HOME="$pnpm_home"
+
+	if ! path_has_entry "$PATH" "$pnpm_home"; then
+		export PATH="${pnpm_home}:$PATH"
+	fi
 
 	if ! path_has_entry "$PATH" "$node_bin"; then
 		export PATH="${node_bin}:$PATH"
@@ -270,7 +286,7 @@ main() {
 
 	node_bin="${pnpm_home}/nodejs/${version}/bin"
 	if [ ! -x "${node_bin}/node" ]; then
-		PATH="$run_path" "$pnpm_bin" env add --global "$version" >&2
+		PNPM_HOME="$pnpm_home" PATH="$run_path" "$pnpm_bin" env add --global "$version" >&2
 	fi
 
 	if [ ! -x "${node_bin}/node" ]; then
@@ -279,14 +295,14 @@ main() {
 	fi
 
 	if [ "$print_export" -eq 1 ]; then
-		emit_export_script "$node_bin"
+		emit_export_script "$pnpm_home" "$node_bin"
 		return 0
 	fi
 
 	if is_sourced; then
-		apply_path "$node_bin"
+		apply_path "$pnpm_home" "$node_bin"
 	else
-		emit_export_script "$node_bin"
+		emit_export_script "$pnpm_home" "$node_bin"
 	fi
 }
 


### PR DESCRIPTION
## Summary
- export `PNPM_HOME` from `pnpm-activate-env`
- ensure `pnpm env add --global` runs with `PNPM_HOME` set
- add an install check covering unset `HOME` and unset `PNPM_HOME`

## Testing
- nix build .#pnpm-standalone --no-link -L

This fixes `ERR_PNPM_CANNOT_MANAGE_NODE` when the helper activates Node in environments where `HOME` and `PNPM_HOME` are not preset.