### PR TITLE
feat(ollama): add linux and macos package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ jobs:
       - name: 🔍 detect changed packages
         id: changes
         run: |
-          LINUX_PACKAGES="agave agave-2_0 agave-2_1 agave-2_2 agave-2_3 agave-3_0 agave-3_1 cargo-interactive-update codex-cli cursor-cli godot knope mdt pina pnpm-standalone racket-minimal surfpool"
-          MACOS_PACKAGES="agave agave-2_0 agave-2_1 agave-2_2 agave-2_3 agave-3_0 agave-3_1 cargo-interactive-update codex-cli codexbar cursor-cli godot google-drive gpg-suite knope mdt nordvpn pina pnpm-standalone racket-minimal steam surfpool zoom"
+          LINUX_PACKAGES="agave agave-2_0 agave-2_1 agave-2_2 agave-2_3 agave-3_0 agave-3_1 cargo-interactive-update codex-cli cursor-cli godot knope mdt ollama pina pnpm-standalone racket-minimal surfpool"
+          MACOS_PACKAGES="agave agave-2_0 agave-2_1 agave-2_2 agave-2_3 agave-3_0 agave-3_1 cargo-interactive-update codex-cli codexbar cursor-cli godot google-drive gpg-suite knope mdt nordvpn ollama pina pnpm-standalone racket-minimal steam surfpool zoom"
 
           build_all=false
 

--- a/flake.nix
+++ b/flake.nix
@@ -31,6 +31,7 @@
         knope = final.callPackage ./packages/knope/package.nix { };
         mdt = final.callPackage ./packages/mdt/package.nix { };
         nordvpn = final.callPackage ./packages/nordvpn/package.nix { };
+        ollama = final.callPackage ./packages/ollama/package.nix { };
         pina = final.callPackage ./packages/pina/package.nix { };
         pnpm-standalone = final.callPackage ./packages/pnpm-standalone/package.nix { };
         racket-minimal = final.callPackage ./packages/racket-minimal/package.nix { };
@@ -66,6 +67,7 @@
           knope = pkgs.callPackage ./packages/knope/package.nix { };
           mdt = pkgs.callPackage ./packages/mdt/package.nix { };
           nordvpn = pkgs.callPackage ./packages/nordvpn/package.nix { };
+          ollama = pkgs.callPackage ./packages/ollama/package.nix { };
           pina = pkgs.callPackage ./packages/pina/package.nix { };
           pnpm-standalone = pkgs.callPackage ./packages/pnpm-standalone/package.nix { };
           racket-minimal = pkgs.callPackage ./packages/racket-minimal/package.nix { };

--- a/packages/ollama/package.nix
+++ b/packages/ollama/package.nix
@@ -1,0 +1,109 @@
+{
+  stdenv,
+  fetchurl,
+  unzip,
+  zstd,
+  autoPatchelfHook,
+  lib,
+}:
+
+let
+  version = "0.20.3";
+
+  platformKey =
+    {
+      "aarch64-darwin" = "darwin";
+      "x86_64-darwin" = "darwin";
+      "aarch64-linux" = "linux-arm64";
+      "x86_64-linux" = "linux-amd64";
+    }
+    .${stdenv.hostPlatform.system} or (throw "Unsupported platform: ${stdenv.hostPlatform.system}");
+
+  assets = {
+    darwin = {
+      url = "https://github.com/ollama/ollama/releases/download/v${version}/Ollama-darwin.zip";
+      hash = "sha256-BlOb85m1cz5kwNACe3eJIWkqpUvGH1oMVAvKwda+3R8=";
+    };
+    "linux-amd64" = {
+      url = "https://github.com/ollama/ollama/releases/download/v${version}/ollama-linux-amd64.tar.zst";
+      hash = "sha256-1nOAYN6WizxUJp1jZxxDI/3z0QW2m5iIYufwaBbHBn4=";
+    };
+    "linux-arm64" = {
+      url = "https://github.com/ollama/ollama/releases/download/v${version}/ollama-linux-arm64.tar.zst";
+      hash = "sha256-sbrSMlpyhGOUmsL1WiM+b8bBMvBjZMvpmqvfUsGQMlA=";
+    };
+  };
+in
+stdenv.mkDerivation {
+  pname = "ollama";
+  inherit version;
+
+  src = fetchurl (assets.${platformKey});
+
+  dontUnpack = true;
+  dontPatch = true;
+  dontConfigure = true;
+  dontBuild = true;
+  dontStrip = true;
+  dontFixup = stdenv.isDarwin;
+
+  nativeBuildInputs =
+    lib.optionals stdenv.isDarwin [ unzip ]
+    ++ lib.optionals stdenv.isLinux [
+      autoPatchelfHook
+      zstd
+    ];
+  buildInputs = lib.optionals stdenv.isLinux [ stdenv.cc.cc.lib ];
+
+  installPhase = ''
+    runHook preInstall
+
+    ${
+      if stdenv.isDarwin then
+        ''
+          mkdir -p $out/Applications $out/bin
+          unzip -q $src -d extracted
+          cp -R extracted/Ollama.app $out/Applications/
+
+          chmod +x $out/Applications/Ollama.app/Contents/MacOS/Ollama
+          chmod +x $out/Applications/Ollama.app/Contents/Resources/ollama
+          ln -s $out/Applications/Ollama.app/Contents/Resources/ollama $out/bin/ollama
+
+          printf '%s\n' '#!${stdenv.shell}' 'exec "$out/Applications/Ollama.app/Contents/MacOS/Ollama" "$@"' > $out/bin/ollama-app
+          chmod +x $out/bin/ollama-app
+        ''
+      else
+        ''
+          mkdir -p $out
+          tar --use-compress-program=unzstd -xf $src -C $out
+
+          chmod +x $out/bin/ollama
+          printf '%s\n' '#!${stdenv.shell}' 'exec "$out/bin/ollama" "$@"' > $out/bin/ollama-app
+          chmod +x $out/bin/ollama-app
+        ''
+    }
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Run local LLMs with Ollama via CLI and desktop app";
+    homepage = "https://ollama.com/";
+    license = licenses.mit;
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+    maintainers = [ ];
+    sourceProvenance = [ sourceTypes.binaryNativeCode ];
+    mainProgram = "ollama";
+    tags = [
+      "cli"
+      "gui"
+      "ai"
+      "llm"
+    ];
+  };
+}

--- a/readme.md
+++ b/readme.md
@@ -25,6 +25,7 @@ Additional Nix packages not yet available in [nixpkgs](https://github.com/NixOS/
 | [knope](#knope)                                       | <!-- {~v_knope:"{{ v.knope }}"} -->0.22.4<!-- {/v_knope} -->                                                         | linux, macos       | Automate common development tasks (changelogs, releases, versioning)          |
 | [mdt](#mdt)                                           | <!-- {~v_mdt:"{{ v.mdt }}"} -->0.7.0<!-- {/v_mdt} -->                                                                | linux, macos       | Update markdown content anywhere using comments as template tags              |
 | [nordvpn](#nordvpn)                                   | <!-- {~v_nordvpn:"{{ v.nordvpn }}"} -->9.15.0<!-- {/v_nordvpn} -->                                                   | macos              | NordVPN macOS client                                                          |
+| [ollama](#ollama)                                     | <!-- {~v_ollama:"{{ v.ollama }}"} -->0.20.3<!-- {/v_ollama} -->                                                      | linux, macos       | Run local LLMs with Ollama via CLI and desktop app                            |
 | [pina](#pina)                                         | <!-- {~v_pina:"{{ v.pina }}"} -->0.8.0<!-- {/v_pina} -->                                                             | linux, macos       | CLI for Pina, a performant Solana smart contract framework                    |
 | [pnpm-standalone](#pnpm-standalone)                   | <!-- {~v_pnpm_standalone:"{{ v.pnpm_standalone }}"} -->10.33.0<!-- {/v_pnpm_standalone} -->                          | linux, macos       | Fast, disk-space efficient package manager (no Node.js dependency)            |
 | [racket-minimal](#racket-minimal)                     | <!-- {~v_racket_minimal:"{{ v.racket_minimal }}"} -->9.1<!-- {/v_racket_minimal} -->                                 | linux, macos       | Racket programming language (minimal distribution, pre-built)                 |
@@ -42,6 +43,7 @@ nix run github:ifiokjr/nixpkgs#mdt
 nix run github:ifiokjr/nixpkgs#pnpm-standalone
 nix run github:ifiokjr/nixpkgs#codex-cli
 nix run github:ifiokjr/nixpkgs#godot
+nix run github:ifiokjr/nixpkgs#ollama
 ```
 
 ### add to your flake
@@ -307,6 +309,15 @@ NordVPN macOS client. Installs the `.app` bundle from the official PKG.
 
 - **License:** Proprietary
 - **Source:** <https://nordvpn.com/>
+
+### ollama
+
+Ollama for running local LLMs. On macOS this installs `Ollama.app` plus the bundled `ollama` CLI. On Linux it installs the official upstream release bundle and provides `ollama` plus an `ollama-app` launcher alias for `nix run` and desktop-style usage.
+
+- **Binary:** `ollama`, `ollama-app`
+- **License:** MIT
+- **Source:** <https://github.com/ollama/ollama>
+- **Homepage:** <https://ollama.com/>
 
 ### pina
 

--- a/scripts/update
+++ b/scripts/update
@@ -3,7 +3,7 @@
 #
 # The script covers:
 # - Flake inputs (nix flake update → flake.lock)
-# - Versioned GitHub release packages (agave, codex-cli, godot, surfpool, etc.)
+# - Versioned GitHub release packages (agave, codex-cli, godot, ollama, surfpool, etc.)
 # - Cursor CLI (version from install script)
 # - Homebrew-cask versioned packages (gpg-suite, nordvpn, zoom)
 # - Rolling URL packages (google-drive, steam)
@@ -575,6 +575,17 @@ def update-godot [packages_dir: string, dry_run: bool] {
   update-versioned-keyed-hashes "godot" $file $latest_version $entries $dry_run
 }
 
+def update-ollama [packages_dir: string, dry_run: bool] {
+  let latest_version = (github-latest-tag "ollama" "ollama" | str replace --regex '^v' '')
+  let file = $"($packages_dir)/ollama/package.nix"
+  let entries = [
+    { key: "darwin", url: $"https://github.com/ollama/ollama/releases/download/v($latest_version)/Ollama-darwin.zip" }
+    { key: "linux-amd64", url: $"https://github.com/ollama/ollama/releases/download/v($latest_version)/ollama-linux-amd64.tar.zst" }
+    { key: "linux-arm64", url: $"https://github.com/ollama/ollama/releases/download/v($latest_version)/ollama-linux-arm64.tar.zst" }
+  ]
+  update-versioned-keyed-hashes "ollama" $file $latest_version $entries $dry_run
+}
+
 def update-pnpm [packages_dir: string, dry_run: bool] {
   let latest_version = (github-latest-tag "pnpm" "pnpm" | str replace --regex '^v' '')
   let file = $"($packages_dir)/pnpm-standalone/package.nix"
@@ -847,6 +858,7 @@ def main [
     { name: "knope", run: {|| update-rust-knope $root $packages_dir $dry_run } }
     { name: "mdt", run: {|| update-rust-mdt $root $packages_dir $dry_run } }
     { name: "nordvpn", run: {|| update-nordvpn $packages_dir $dry_run } }
+    { name: "ollama", run: {|| update-ollama $packages_dir $dry_run } }
     { name: "pina", run: {|| update-rust-pina $root $packages_dir $dry_run } }
     { name: "pnpm-standalone", run: {|| update-pnpm $packages_dir $dry_run } }
     { name: "racket-minimal", run: {|| update-racket $packages_dir $dry_run } }


### PR DESCRIPTION
## Summary
- add an `ollama` package for Linux and macOS using upstream release artifacts
- install the macOS app bundle and expose the bundled CLI
- add updater, CI, flake, and README integration

## Validation
- `nix build .#ollama`
- `nix shell nixpkgs#nushell -c nu scripts/update --dry-run`
