### PR TITLE
fix(ollama): patch linux runtime dependencies

### DIFF
--- a/packages/ollama/package.nix
+++ b/packages/ollama/package.nix
@@ -4,6 +4,7 @@
   unzip,
   zstd,
   autoPatchelfHook,
+  zlib,
   lib,
 }:
 
@@ -53,7 +54,12 @@ stdenv.mkDerivation {
       autoPatchelfHook
       zstd
     ];
-  buildInputs = lib.optionals stdenv.isLinux [ stdenv.cc.cc.lib ];
+  buildInputs = lib.optionals stdenv.isLinux [
+    stdenv.cc.cc.lib
+    zlib
+  ];
+
+  autoPatchelfIgnoreMissingDeps = lib.optionals stdenv.isLinux [ "libcuda.so.1" ];
 
   installPhase = ''
     runHook preInstall


### PR DESCRIPTION
## Summary
- add `zlib` to Linux build inputs for Ollama
- ignore missing `libcuda.so.1` during auto-patchelf for optional GPU libraries
- fix the failing Linux CI build for `ollama` on `main`

## Root cause
The Linux release bundle includes optional CUDA/MLX libraries. CI failed during `autoPatchelfHook` because `libcuda.so.1` is not available on the runner, and some bundled libraries also needed `libz.so.1`.

## Validation
- inspected failing Actions log for `build ollama (linux)`
- `nix build .#ollama` on macOS still succeeds
