### PR TITLE
feat(agave): add versioned release tracks

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,8 @@
         agave-2_2 = final.callPackage ./packages/agave-2_2/package.nix { };
         agave-2_3 = final.callPackage ./packages/agave-2_3/package.nix { };
         agave-3_0 = final.callPackage ./packages/agave-3_0/package.nix { };
-        agave-3_1 = agave;
+        agave-3_1 = final.callPackage ./packages/agave-3_1/package.nix { };
+        agave-4_0 = final.callPackage ./packages/agave-4_0/package.nix { };
         cargo-interactive-update = final.callPackage ./packages/cargo-interactive-update/package.nix { };
         codex-cli = final.callPackage ./packages/codex-cli/package.nix { };
         codexbar = final.callPackage ./packages/codexbar/package.nix { };
@@ -56,7 +57,8 @@
           agave-2_2 = pkgs.callPackage ./packages/agave-2_2/package.nix { };
           agave-2_3 = pkgs.callPackage ./packages/agave-2_3/package.nix { };
           agave-3_0 = pkgs.callPackage ./packages/agave-3_0/package.nix { };
-          agave-3_1 = agave;
+          agave-3_1 = pkgs.callPackage ./packages/agave-3_1/package.nix { };
+          agave-4_0 = pkgs.callPackage ./packages/agave-4_0/package.nix { };
           cargo-interactive-update = pkgs.callPackage ./packages/cargo-interactive-update/package.nix { };
           codex-cli = pkgs.callPackage ./packages/codex-cli/package.nix { };
           codexbar = pkgs.callPackage ./packages/codexbar/package.nix { };

--- a/packages/agave-3_1/package.nix
+++ b/packages/agave-3_1/package.nix
@@ -1,0 +1,35 @@
+{
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  makeWrapper,
+  lib,
+  zlib,
+  openssl,
+  udev,
+}:
+
+let
+  version = "3.1.12";
+
+  hashes = {
+    "aarch64-apple-darwin" = "sha256-8q1QM0h5VP/ec3FzNoJ/ybn7EQMIQ+SVajDI0otY4/k=";
+    "x86_64-apple-darwin" = "sha256-FkJMC5CazkW/sue2EIETyUB7gmKafm2Jrb2CDT6vzTo=";
+    "x86_64-unknown-linux-gnu" = "sha256-TUXatsz+UyEpKtbcFS96znHMvd3l7NoKqj+Su/6O2AM=";
+  };
+in
+import ../agave/common.nix {
+  inherit
+    stdenv
+    fetchurl
+    autoPatchelfHook
+    makeWrapper
+    lib
+    zlib
+    openssl
+    udev
+    version
+    hashes
+    ;
+  pname = "agave-3_1";
+}

--- a/packages/agave-4_0/package.nix
+++ b/packages/agave-4_0/package.nix
@@ -1,0 +1,35 @@
+{
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  makeWrapper,
+  lib,
+  zlib,
+  openssl,
+  udev,
+}:
+
+let
+  version = "4.0.0-beta.6";
+
+  hashes = {
+    "aarch64-apple-darwin" = "sha256-t9zfuhV8rwUzn87/N/spy62j4VyifrTT+kmnDbd4AGs=";
+    "x86_64-apple-darwin" = "sha256-ITOusiHnIjuv7BA2QNDZNSqzFQZZ79BFdxDN0o2Ym/4=";
+    "x86_64-unknown-linux-gnu" = "sha256-hbhar6iPv85csrOB/BXogtd7336E/xRGIEvj+zrVO2s=";
+  };
+in
+import ../agave/common.nix {
+  inherit
+    stdenv
+    fetchurl
+    autoPatchelfHook
+    makeWrapper
+    lib
+    zlib
+    openssl
+    udev
+    version
+    hashes
+    ;
+  pname = "agave-4_0";
+}

--- a/scripts/update
+++ b/scripts/update
@@ -524,15 +524,63 @@ def update-rolling-single-hash [
 
 # Per-package update definitions
 
-def update-agave [packages_dir: string, dry_run: bool] {
-  let latest_version = (github-latest-tag "anza-xyz" "agave" | str replace --regex '^v' '')
-  let file = $"($packages_dir)/agave/package.nix"
+def update-agave-package [packages_dir: string, package_name: string, latest_version: string, dry_run: bool] {
+  let file = $"($packages_dir)/($package_name)/package.nix"
   let entries = [
     { key: "aarch64-apple-darwin", url: $"https://github.com/anza-xyz/agave/releases/download/v($latest_version)/solana-release-aarch64-apple-darwin.tar.bz2" }
     { key: "x86_64-apple-darwin", url: $"https://github.com/anza-xyz/agave/releases/download/v($latest_version)/solana-release-x86_64-apple-darwin.tar.bz2" }
     { key: "x86_64-unknown-linux-gnu", url: $"https://github.com/anza-xyz/agave/releases/download/v($latest_version)/solana-release-x86_64-unknown-linux-gnu.tar.bz2" }
   ]
-  update-versioned-keyed-hashes "agave" $file $latest_version $entries $dry_run
+  update-versioned-keyed-hashes $package_name $file $latest_version $entries $dry_run
+}
+
+def update-agave-track [packages_dir: string, package_name: string, version_prefix: string, dry_run: bool] {
+  let latest_version = (
+    github-latest-tag-with-prefix "anza-xyz" "agave" $"v($version_prefix)."
+    | str replace --regex '^v' ''
+  )
+  update-agave-package $packages_dir $package_name $latest_version $dry_run
+}
+
+def update-agave-beta-track [packages_dir: string, package_name: string, version_prefix: string, dry_run: bool] {
+  let latest_version = (
+    github-latest-tag-with-prefix "anza-xyz" "agave" $"v($version_prefix).0-beta."
+    | str replace --regex '^v' ''
+  )
+  update-agave-package $packages_dir $package_name $latest_version $dry_run
+}
+
+def update-agave [packages_dir: string, dry_run: bool] {
+  let latest_version = (github-latest-tag "anza-xyz" "agave" | str replace --regex '^v' '')
+  update-agave-package $packages_dir "agave" $latest_version $dry_run
+}
+
+def update-agave-4-0 [packages_dir: string, dry_run: bool] {
+  update-agave-beta-track $packages_dir "agave-4_0" "4.0" $dry_run
+}
+
+def update-agave-3-1 [packages_dir: string, dry_run: bool] {
+  update-agave-track $packages_dir "agave-3_1" "3.1" $dry_run
+}
+
+def update-agave-3-0 [packages_dir: string, dry_run: bool] {
+  update-agave-track $packages_dir "agave-3_0" "3.0" $dry_run
+}
+
+def update-agave-2-3 [packages_dir: string, dry_run: bool] {
+  update-agave-track $packages_dir "agave-2_3" "2.3" $dry_run
+}
+
+def update-agave-2-2 [packages_dir: string, dry_run: bool] {
+  update-agave-track $packages_dir "agave-2_2" "2.2" $dry_run
+}
+
+def update-agave-2-1 [packages_dir: string, dry_run: bool] {
+  update-agave-track $packages_dir "agave-2_1" "2.1" $dry_run
+}
+
+def update-agave-2-0 [packages_dir: string, dry_run: bool] {
+  update-agave-track $packages_dir "agave-2_0" "2.0" $dry_run
 }
 
 def update-codex [packages_dir: string, dry_run: bool] {
@@ -850,6 +898,13 @@ def main [
 
   mut steps = [
     { name: "agave", run: {|| update-agave $packages_dir $dry_run } }
+    { name: "agave-2_0", run: {|| update-agave-2-0 $packages_dir $dry_run } }
+    { name: "agave-2_1", run: {|| update-agave-2-1 $packages_dir $dry_run } }
+    { name: "agave-2_2", run: {|| update-agave-2-2 $packages_dir $dry_run } }
+    { name: "agave-2_3", run: {|| update-agave-2-3 $packages_dir $dry_run } }
+    { name: "agave-3_0", run: {|| update-agave-3-0 $packages_dir $dry_run } }
+    { name: "agave-3_1", run: {|| update-agave-3-1 $packages_dir $dry_run } }
+    { name: "agave-4_0", run: {|| update-agave-4-0 $packages_dir $dry_run } }
     { name: "cargo-interactive-update", run: {|| update-rust-cargo-interactive $root $packages_dir $dry_run } }
     { name: "codex-cli", run: {|| update-codex $packages_dir $dry_run } }
     { name: "cursor-cli", run: {|| update-cursor $packages_dir $dry_run } }


### PR DESCRIPTION
## Summary
- keep `agave` on the latest Agave release overall
- add dedicated versioned Agave packages for `3.1`, `3.0`, `2.3`, `2.2`, `2.1`, `2.0`, and `4.0` beta releases
- teach `scripts/update` to update each package against its intended release line

## Validation
- `nu scripts/update --repo-root . --dry-run`
- `nix eval .#packages.$(nix eval --impure --expr builtins.currentSystem --raw).agave-3_1.pname --raw`
- `nix eval .#packages.$(nix eval --impure --expr builtins.currentSystem --raw).agave-4_0.pname --raw`