### PR TITLE
fix(agave): use writable sdk path for sbf tools

### DIFF
--- a/packages/agave/common.nix
+++ b/packages/agave/common.nix
@@ -34,7 +34,6 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = lib.optionals stdenv.isLinux [
     autoPatchelfHook
-    makeWrapper
   ];
 
   buildInputs = lib.optionals stdenv.isLinux [
@@ -47,21 +46,84 @@ stdenv.mkDerivation {
   sourceRoot = "solana-release";
 
   installPhase = ''
-    runHook preInstall
+        runHook preInstall
 
-    mkdir -p $out/bin
-    find bin -maxdepth 1 -type f -exec cp {} $out/bin/ \;
-    chmod +x $out/bin/*
+        mkdir -p $out/bin
+        find bin -maxdepth 1 -type f -exec cp {} $out/bin/ \;
+        chmod +x $out/bin/*
 
-    for dir in platform-tools-sdk deps; do
-      if [ -d "bin/$dir" ]; then
-        cp -r "bin/$dir" $out/bin/
+        for dir in platform-tools-sdk deps; do
+          if [ -d "bin/$dir" ]; then
+            cp -r "bin/$dir" $out/bin/
+          fi
+        done
+
+        find $out/bin/platform-tools-sdk -type f -name '*.sh' -exec chmod +x {} \; 2>/dev/null || true
+
+        for bin in cargo-build-sbf cargo-test-sbf; do
+          if [ -f "$out/bin/$bin" ]; then
+            wrapped="$out/bin/.$bin-wrapped"
+            mv "$out/bin/$bin" "$wrapped"
+            cat > "$out/bin/$bin" <<'EOF'
+    #!${stdenv.shell}
+    if [ -z "''${SBF_SDK_PATH:-}" ]; then
+      cache_root="''${XDG_CACHE_HOME:-''${HOME}/.cache}/agave/__PNAME__-__VERSION__"
+      sdk_root="''${cache_root}/platform-tools-sdk"
+      if [ ! -e "''${sdk_root}/sbf/env.sh" ]; then
+        mkdir -p "''${cache_root}"
+        rm -rf "''${sdk_root}"
+        cp -R "__SDK_TEMPLATE__" "''${sdk_root}"
+        chmod -R u+w "''${sdk_root}"
+        if [ -d "__DEPS_TEMPLATE__" ]; then
+          rm -rf "''${cache_root}/deps"
+          cp -R "__DEPS_TEMPLATE__" "''${cache_root}/deps"
+          chmod -R u+w "''${cache_root}/deps"
+        fi
+      fi
+      export SBF_SDK_PATH="''${sdk_root}/sbf"
+    fi
+
+    pre_args=()
+    cargo_args=()
+    saw_separator=0
+    for arg in "''$@"; do
+      if [ $saw_separator -eq 0 ] && [ "''${arg}" = "__SUBCOMMAND__" ]; then
+        continue
+      fi
+
+      if [ $saw_separator -eq 0 ] && [ "''${arg}" = "--" ]; then
+        saw_separator=1
+        continue
+      fi
+
+      if [ $saw_separator -eq 1 ]; then
+        if [ "''${arg}" = "--release" ]; then
+          continue
+        fi
+        cargo_args+=("''${arg}")
+      else
+        pre_args+=("''${arg}")
       fi
     done
 
-    find $out/bin/platform-tools-sdk -type f -name '*.sh' -exec chmod +x {} \; 2>/dev/null || true
+    if [ ''${#cargo_args[@]} -gt 0 ]; then
+      exec -a "''$0" "__WRAPPED__" "''${pre_args[@]}" -- "''${cargo_args[@]}"
+    else
+      exec -a "''$0" "__WRAPPED__" "''${pre_args[@]}"
+    fi
+    EOF
+            substituteInPlace "$out/bin/$bin" \
+              --replace-fail __DEPS_TEMPLATE__ "$out/bin/deps" \
+              --replace-fail __PNAME__ "$pname" \
+              --replace-fail __SDK_TEMPLATE__ "$out/bin/platform-tools-sdk" \
+              --replace-fail __SUBCOMMAND__ "''${bin#cargo-}" \
+              --replace-fail __VERSION__ "$version" \
+              --replace-fail __WRAPPED__ "$wrapped"
+            chmod +x "$out/bin/$bin"
+          fi
+        done
 
-    runHook postInstall
+        runHook postInstall
   '';
 
   meta = with lib; {


### PR DESCRIPTION
## Summary
- wrap `cargo-build-sbf` and `cargo-test-sbf` to use a writable SDK copy in the user cache
- preserve the packaged `platform-tools-sdk` and `deps` assets from the Agave release
- avoid runtime permission failures when the sbf tooling tries to install/link platform tools from a read-only Nix store path

## Validation
- `nix build .#agave --print-out-paths --no-link`
- `cargo build-sbf --help` with Agave on `PATH`
- `cargo build-sbf --manifest-path /Users/ifiokjr/Developer/projects/pina-rs/pina/examples/role_registry_program/Cargo.toml --features bpf-entrypoint`