### PR TITLE
fix(google-drive): update rolling DMG hash

### DIFF
--- a/packages/google-drive/package.nix
+++ b/packages/google-drive/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://dl.google.com/drive-file-stream/5-percent/GoogleDrive.dmg";
-    hash = "sha256-o5kpotbTND5r5WICUHOvsVP5NjBtgThpr1nHCiYBCJ8=";
+    hash = "sha256-sq26uY6KME65Xjof9kuHABD8RFkXtgD0LIBEeGTgFig=";
   };
 
   nativeBuildInputs = [ undmg ];


### PR DESCRIPTION
## Summary
- Update google-drive DMG hash after upstream changed the binary at the same URL
- This was causing CI failures on main

## Test plan
- [ ] CI: `build google-drive (macos)` passes