### PR TITLE
fix(packages): use release tarballs for mdt and cargoLock for pina

### DIFF
--- a/packages/mdt/package.nix
+++ b/packages/mdt/package.nix
@@ -1,34 +1,67 @@
 {
+  stdenv,
+  fetchurl,
   lib,
-  rustPlatform,
-  fetchFromGitHub,
 }:
 
-rustPlatform.buildRustPackage (finalAttrs: {
-  pname = "mdt";
+let
   version = "0.7.0";
+  tag = "v${version}";
 
-  src = fetchFromGitHub {
-    owner = "ifiokjr";
-    repo = "mdt";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-x31WDYHzD1MOr2CEnCwe43HrEg5clJXJtWiFVKJs2fY=";
+  platformSuffix =
+    {
+      "aarch64-darwin" = "aarch64-apple-darwin";
+      "x86_64-darwin" = "x86_64-apple-darwin";
+      "aarch64-linux" = "aarch64-unknown-linux-musl";
+      "x86_64-linux" = "x86_64-unknown-linux-musl";
+    }
+    .${stdenv.hostPlatform.system} or (throw "Unsupported platform: ${stdenv.hostPlatform.system}");
+
+  hashes = {
+    "aarch64-apple-darwin" = "sha256-pgJjrD3W8Is00zBTfBBJ4I0vNtdj3Z2K+FYWTCHsLKE=";
+    "x86_64-apple-darwin" = "sha256-ehK1h1o9R9arR4fQSiDJbsa+4xStVbInoaty8PiRV3E=";
+    "aarch64-unknown-linux-musl" = "sha256-Gy187xh3SOBiAgCl2yJXnPmWz2TeuTBcHkBaIulIkNM=";
+    "x86_64-unknown-linux-musl" = "sha256-d4AuyUfuD8rXiL9cmUDw32w+HEojIeNnNrCEBGUDQy4=";
+  };
+in
+stdenv.mkDerivation {
+  pname = "mdt";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://github.com/ifiokjr/mdt/releases/download/${tag}/mdt-${platformSuffix}-${tag}.tar.gz";
+    sha256 = hashes.${platformSuffix} or lib.fakeSha256;
   };
 
-  cargoHash = "sha256-rFN5SiYk7qfUF2uJ+PDSmVtVmiAHn7hu1eqApaJN+0Y=";
+  dontBuild = true;
+  dontStrip = stdenv.isDarwin;
 
-  buildAndTestSubdir = "mdt_cli";
+  sourceRoot = ".";
 
-  doCheck = false;
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp mdt $out/bin/mdt
+    chmod +x $out/bin/mdt
+
+    runHook postInstall
+  '';
 
   meta = {
     description = "CLI that updates markdown content anywhere using comments as template tags";
     homepage = "https://github.com/ifiokjr/mdt";
     license = lib.licenses.unlicense;
     mainProgram = "mdt";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
     tags = [
       "cli"
       "dev-tool"
     ];
   };
-})
+}

--- a/packages/pina/package.nix
+++ b/packages/pina/package.nix
@@ -15,7 +15,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
     hash = "sha256-srg1y6XwjNjr75tVOtb7vM8HIInzk6ka0+Vn88mqZwM=";
   };
 
-  cargoHash = "sha256-sx5X/VqOOcMmHiBTVDK/J4kFlMwQCWptyPdm4AydywM=";
+  cargoLock = {
+    lockFile = "${finalAttrs.src}/Cargo.lock";
+  };
 
   buildAndTestSubdir = "crates/pina_cli";
 


### PR DESCRIPTION
## Summary
- package `mdt` from GitHub release tarballs instead of building from source
- switch `pina` from `cargoHash` to `cargoLock` to avoid the crates.io vendoring failure path
- keep both packages building in Nix

## Notes
- `mdt` publishes prebuilt release binaries for macOS and Linux, so this should speed downstream installs and avoid vendoring issues.
- `pina` does not currently publish matching release tarballs for the packaged `v0.8.0`, so this PR keeps it source-built but moves it to `cargoLock`.