### PR TITLE
feat(monochange): add monochange release package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ jobs:
       - name: 🔍 detect changed packages
         id: changes
         run: |
-          LINUX_PACKAGES="agave agave-2_0 agave-2_1 agave-2_2 agave-2_3 agave-3_0 agave-3_1 cargo-dylint cargo-interactive-update codex-cli dylint-link godot knope mdt ollama pina pnpm pnpm-10 pnpm-11 pnpm-standalone racket-minimal surfpool wait-for-them"
-          MACOS_PACKAGES="agave agave-2_0 agave-2_1 agave-2_2 agave-2_3 agave-3_0 agave-3_1 cargo-dylint cargo-interactive-update codex-cli codexbar dylint-link godot gpg-suite knope mdt nordvpn ollama pina pnpm pnpm-10 pnpm-11 pnpm-standalone racket-minimal steam surfpool zoom"
+          LINUX_PACKAGES="agave agave-2_0 agave-2_1 agave-2_2 agave-2_3 agave-3_0 agave-3_1 cargo-dylint cargo-interactive-update codex-cli dylint-link godot knope mdt monochange ollama pina pnpm pnpm-10 pnpm-11 pnpm-standalone racket-minimal surfpool wait-for-them"
+          MACOS_PACKAGES="agave agave-2_0 agave-2_1 agave-2_2 agave-2_3 agave-3_0 agave-3_1 cargo-dylint cargo-interactive-update codex-cli codexbar dylint-link godot gpg-suite knope mdt monochange nordvpn ollama pina pnpm pnpm-10 pnpm-11 pnpm-standalone racket-minimal steam surfpool zoom"
 
           build_all=false
 

--- a/flake.nix
+++ b/flake.nix
@@ -31,6 +31,7 @@
         gpg-suite = final.callPackage ./packages/gpg-suite/package.nix { };
         knope = final.callPackage ./packages/knope/package.nix { };
         mdt = final.callPackage ./packages/mdt/package.nix { };
+        monochange = final.callPackage ./packages/monochange/package.nix { };
         nordvpn = final.callPackage ./packages/nordvpn/package.nix { };
         ollama = final.callPackage ./packages/ollama/package.nix { };
         pina = final.callPackage ./packages/pina/package.nix { };
@@ -72,6 +73,7 @@
           gpg-suite = pkgs.callPackage ./packages/gpg-suite/package.nix { };
           knope = pkgs.callPackage ./packages/knope/package.nix { };
           mdt = pkgs.callPackage ./packages/mdt/package.nix { };
+          monochange = pkgs.callPackage ./packages/monochange/package.nix { };
           nordvpn = pkgs.callPackage ./packages/nordvpn/package.nix { };
           ollama = pkgs.callPackage ./packages/ollama/package.nix { };
           pina = pkgs.callPackage ./packages/pina/package.nix { };

--- a/mdt.toml
+++ b/mdt.toml
@@ -15,6 +15,7 @@ v = { command = "./scripts/versions", format = "json", watch = [
 	"packages/gpg-suite/package.nix",
 	"packages/knope/package.nix",
 	"packages/mdt/package.nix",
+	"packages/monochange/package.nix",
 	"packages/nordvpn/package.nix",
 	"packages/pina/package.nix",
 	"packages/pnpm/package.nix",

--- a/packages/monochange/package.nix
+++ b/packages/monochange/package.nix
@@ -1,0 +1,70 @@
+{
+  stdenv,
+  fetchurl,
+  lib,
+}:
+
+let
+  version = "0.2.0";
+  tag = "v${version}";
+
+  platformSuffix =
+    {
+      "aarch64-darwin" = "aarch64-apple-darwin";
+      "x86_64-darwin" = "x86_64-apple-darwin";
+      "aarch64-linux" = "aarch64-unknown-linux-musl";
+      "x86_64-linux" = "x86_64-unknown-linux-musl";
+    }
+    .${stdenv.hostPlatform.system} or (throw "Unsupported platform: ${stdenv.hostPlatform.system}");
+
+  hashes = {
+    "aarch64-apple-darwin" = "sha256-n1RAb9/tOaE3uGOLG+gdNbAoo4e67DDQFlFlCFa1vAk=";
+    "x86_64-apple-darwin" = "sha256-rt8DoCuPYKN6DsaQ6qWaWiDF77cKrG3zeFro0Sb9QEo=";
+    "aarch64-unknown-linux-musl" = "sha256-OPQXzG7kSkq0GZRm8/T/qbWds+mk165qodhvflGtMd4=";
+    "x86_64-unknown-linux-musl" = "sha256-qjVGXZzgZJufqh0I/g51baH+okEj/Ghu2alnQb+ZVgE=";
+  };
+in
+stdenv.mkDerivation {
+  pname = "monochange";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://github.com/ifiokjr/monochange/releases/download/${tag}/monochange-${platformSuffix}-${tag}.tar.gz";
+    sha256 = hashes.${platformSuffix} or lib.fakeSha256;
+  };
+
+  dontBuild = true;
+  dontStrip = stdenv.isDarwin;
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp monochange $out/bin/monochange
+    chmod +x $out/bin/monochange
+    ln -s $out/bin/monochange $out/bin/mc
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Manage versions and releases for your multiplatform, multilanguage monorepo";
+    homepage = "https://ifiokjr.github.io/monochange/";
+    license = lib.licenses.unlicense;
+    mainProgram = "monochange";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+    tags = [
+      "cli"
+      "dev-tool"
+      "release"
+      "monorepo"
+    ];
+  };
+}

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/ifiokjr/nixpkgs/actions/workflows/ci.yml/badge.svg)](https://github.com/ifiokjr/nixpkgs/actions/workflows/ci.yml) [![Nix Flake](https://img.shields.io/badge/nix-flake-blue?logo=nixos)](https://nixos.wiki/wiki/Flakes) [![License](https://img.shields.io/github/license/ifiokjr/nixpkgs)](https://github.com/ifiokjr/nixpkgs/blob/main/LICENSE)
 
-Additional Nix packages not yet available in [nixpkgs](https://github.com/NixOS/nixpkgs). Includes macOS GUI applications, standalone CLI tools, and Rust crates built from source.
+Additional Nix packages not yet available in [nixpkgs](https://github.com/NixOS/nixpkgs). Includes macOS GUI applications, standalone CLI tools, pre-built release packages, and Rust crates built from source.
 
 ## packages
 
@@ -24,6 +24,7 @@ Additional Nix packages not yet available in [nixpkgs](https://github.com/NixOS/
 | [gpg-suite](#gpg-suite)                               | <!-- {~v_gpg_suite:"{{ v.gpg_suite }}"} -->2023.3<!-- {/v_gpg_suite} -->                                             | macos                    | GPG Suite - encryption, signing, and key management                           |
 | [knope](#knope)                                       | <!-- {~v_knope:"{{ v.knope }}"} -->0.22.4<!-- {/v_knope} -->                                                         | linux, macos             | Automate common development tasks (changelogs, releases, versioning)          |
 | [mdt](#mdt)                                           | <!-- {~v_mdt:"{{ v.mdt }}"} -->0.7.0<!-- {/v_mdt} -->                                                                | linux, macos             | Update markdown content anywhere using comments as template tags              |
+| [monochange](#monochange)                             | <!-- {~v_monochange:"{{ v.monochange }}"} -->0.2.0<!-- {/v_monochange} -->                                           | linux, macos             | Manage versions and releases for your multiplatform monorepo                  |
 | [nordvpn](#nordvpn)                                   | <!-- {~v_nordvpn:"{{ v.nordvpn }}"} -->10.0.4<!-- {/v_nordvpn} -->                                                   | macos                    | NordVPN macOS client                                                          |
 | [ollama](#ollama)                                     | <!-- {~v_ollama:"{{ v.ollama }}"} -->0.21.1<!-- {/v_ollama} -->                                                      | linux, macos             | Run local LLMs with Ollama via CLI and desktop app                            |
 | [pina](#pina)                                         | <!-- {~v_pina:"{{ v.pina }}"} -->0.8.0<!-- {/v_pina} -->                                                             | linux, macos             | CLI for Pina, a performant Solana smart contract framework                    |
@@ -41,6 +42,7 @@ Additional Nix packages not yet available in [nixpkgs](https://github.com/NixOS/
 ```bash
 nix run github:ifiokjr/nixpkgs#knope
 nix run github:ifiokjr/nixpkgs#mdt
+nix run github:ifiokjr/nixpkgs#monochange
 nix run github:ifiokjr/nixpkgs#pnpm-standalone
 nix run github:ifiokjr/nixpkgs#codex-cli
 nix run github:ifiokjr/nixpkgs#godot
@@ -68,6 +70,7 @@ nix run github:ifiokjr/nixpkgs#ollama
         packages = [
           extra.knope
           extra.mdt
+          extra.monochange
           extra.pnpm-standalone
           extra.codex-cli
         ];
@@ -101,6 +104,7 @@ The overlay adds all packages into your nixpkgs set so you can reference them as
         packages = [
           pkgs.knope
           pkgs.mdt
+          pkgs.monochange
           pkgs.pnpm-standalone
         ];
       };
@@ -130,6 +134,7 @@ in
   packages = [
     extra.knope
     extra.mdt
+    extra.monochange
     extra.pnpm-standalone
   ];
 }
@@ -297,11 +302,20 @@ A developer workflow automation tool. Automates changelogs, releases, and versio
 
 ### mdt
 
-CLI tool that updates markdown content anywhere using comments as template tags. Built from source using `rustPlatform.buildRustPackage`.
+CLI tool that updates markdown content anywhere using comments as template tags. Pre-built binary from GitHub releases.
 
 - **Binary:** `mdt`
 - **License:** Unlicense
 - **Source:** <https://github.com/ifiokjr/mdt>
+
+### monochange
+
+Manage versions and releases for your multiplatform, multilanguage monorepo. Pre-built binary from GitHub releases.
+
+- **Binary:** `monochange`, `mc`
+- **License:** Unlicense
+- **Source:** <https://github.com/ifiokjr/monochange>
+- **Homepage:** <https://ifiokjr.github.io/monochange/>
 
 ### nordvpn
 
@@ -449,7 +463,7 @@ The script updates:
 - GitHub release packages (version + platform hashes)
 - Homebrew-cask packages (`gpg-suite`, `nordvpn`, `zoom`)
 - Rolling URL packages (`steam`)
-- Rust packages built from source (`cargo-dylint`, `cargo-interactive-update`, `dylint-link`, `knope`, `mdt`, `pina`)
+- Rust packages built from source (`cargo-dylint`, `cargo-interactive-update`, `dylint-link`, `knope`, `pina`)
 
 ### binary packages (pre-built)
 

--- a/scripts/update
+++ b/scripts/update
@@ -3,11 +3,10 @@
 #
 # The script covers:
 # - Flake inputs (nix flake update → flake.lock)
-# - Versioned GitHub release packages (agave, codex-cli, godot, ollama, surfpool, etc.)
-# 
+# - Versioned GitHub release packages (agave, codex-cli, godot, mdt, monochange, ollama, surfpool, etc.)
 # - Homebrew-cask versioned packages (gpg-suite, nordvpn, zoom)
 # - Rolling URL packages (steam)
-# - Rust packages built from source (cargo-dylint, cargo-interactive-update, dylint-link, knope, mdt, pina)
+# - Rust packages built from source (cargo-dylint, cargo-interactive-update, dylint-link, knope, pina)
 
 # ANSI helpers
 
@@ -955,11 +954,28 @@ def update-rust-knope [repo_root: string, packages_dir: string, dry_run: bool] {
   update-rust-package $repo_root $packages_dir "knope" $latest_version $rev "knope-dev" "knope" $dry_run
 }
 
-def update-rust-mdt [repo_root: string, packages_dir: string, dry_run: bool] {
-  let tag = (github-latest-tag "ifiokjr" "mdt")
-  let latest_version = ($tag | str replace --regex '^v' '')
-  let rev = $"v($latest_version)"
-  update-rust-package $repo_root $packages_dir "mdt" $latest_version $rev "ifiokjr" "mdt" $dry_run
+def update-mdt [packages_dir: string, dry_run: bool] {
+  let latest_version = (github-latest-tag "ifiokjr" "mdt" | str replace --regex '^v' '')
+  let file = $"($packages_dir)/mdt/package.nix"
+  let entries = [
+    { key: "aarch64-apple-darwin", url: $"https://github.com/ifiokjr/mdt/releases/download/v($latest_version)/mdt-aarch64-apple-darwin-v($latest_version).tar.gz" }
+    { key: "x86_64-apple-darwin", url: $"https://github.com/ifiokjr/mdt/releases/download/v($latest_version)/mdt-x86_64-apple-darwin-v($latest_version).tar.gz" }
+    { key: "aarch64-unknown-linux-musl", url: $"https://github.com/ifiokjr/mdt/releases/download/v($latest_version)/mdt-aarch64-unknown-linux-musl-v($latest_version).tar.gz" }
+    { key: "x86_64-unknown-linux-musl", url: $"https://github.com/ifiokjr/mdt/releases/download/v($latest_version)/mdt-x86_64-unknown-linux-musl-v($latest_version).tar.gz" }
+  ]
+  update-versioned-keyed-hashes "mdt" $file $latest_version $entries $dry_run
+}
+
+def update-monochange [packages_dir: string, dry_run: bool] {
+  let latest_version = (github-latest-tag "ifiokjr" "monochange" | str replace --regex '^v' '')
+  let file = $"($packages_dir)/monochange/package.nix"
+  let entries = [
+    { key: "aarch64-apple-darwin", url: $"https://github.com/ifiokjr/monochange/releases/download/v($latest_version)/monochange-aarch64-apple-darwin-v($latest_version).tar.gz" }
+    { key: "x86_64-apple-darwin", url: $"https://github.com/ifiokjr/monochange/releases/download/v($latest_version)/monochange-x86_64-apple-darwin-v($latest_version).tar.gz" }
+    { key: "aarch64-unknown-linux-musl", url: $"https://github.com/ifiokjr/monochange/releases/download/v($latest_version)/monochange-aarch64-unknown-linux-musl-v($latest_version).tar.gz" }
+    { key: "x86_64-unknown-linux-musl", url: $"https://github.com/ifiokjr/monochange/releases/download/v($latest_version)/monochange-x86_64-unknown-linux-musl-v($latest_version).tar.gz" }
+  ]
+  update-versioned-keyed-hashes "monochange" $file $latest_version $entries $dry_run
 }
 
 def update-rust-pina [repo_root: string, packages_dir: string, dry_run: bool] {
@@ -1090,7 +1106,8 @@ def main [
     { name: "godot", run: {|| update-godot $packages_dir $dry_run } }
     { name: "gpg-suite", run: {|| update-gpg-suite $packages_dir $dry_run } }
     { name: "knope", run: {|| update-rust-knope $root $packages_dir $dry_run } }
-    { name: "mdt", run: {|| update-rust-mdt $root $packages_dir $dry_run } }
+    { name: "mdt", run: {|| update-mdt $packages_dir $dry_run } }
+    { name: "monochange", run: {|| update-monochange $packages_dir $dry_run } }
     { name: "nordvpn", run: {|| update-nordvpn $packages_dir $dry_run } }
     { name: "ollama", run: {|| update-ollama $packages_dir $dry_run } }
     { name: "pina", run: {|| update-rust-pina $root $packages_dir $dry_run } }


### PR DESCRIPTION
## Summary
- add `monochange` from upstream GitHub release tarballs
- expose `monochange` and `mc` through the flake
- register the package in CI, docs, and update automation

## Verification
- dprint fmt
- nix build .#monochange --no-link -L
- nix shell .#monochange -c monochange --help
- nix shell .#monochange -c mc --help
- nix run .#mdt -- check
- nix flake show