### PR TITLE
feat(cargo-clean-all): add package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,6 +22,7 @@
         agave-3_0 = final.callPackage ./packages/agave-3_0/package.nix { };
         agave-3_1 = final.callPackage ./packages/agave-3_1/package.nix { };
         agave-4_0 = final.callPackage ./packages/agave-4_0/package.nix { };
+        cargo-clean-all = final.callPackage ./packages/cargo-clean-all/package.nix { };
         cargo-dylint = final.callPackage ./packages/cargo-dylint/package.nix { };
         cargo-interactive-update = final.callPackage ./packages/cargo-interactive-update/package.nix { };
         codex-cli = final.callPackage ./packages/codex-cli/package.nix { };
@@ -64,6 +65,7 @@
           agave-3_0 = pkgs.callPackage ./packages/agave-3_0/package.nix { };
           agave-3_1 = pkgs.callPackage ./packages/agave-3_1/package.nix { };
           agave-4_0 = pkgs.callPackage ./packages/agave-4_0/package.nix { };
+          cargo-clean-all = pkgs.callPackage ./packages/cargo-clean-all/package.nix { };
           cargo-dylint = pkgs.callPackage ./packages/cargo-dylint/package.nix { };
           cargo-interactive-update = pkgs.callPackage ./packages/cargo-interactive-update/package.nix { };
           codex-cli = pkgs.callPackage ./packages/codex-cli/package.nix { };

--- a/packages/cargo-clean-all/package.nix
+++ b/packages/cargo-clean-all/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "cargo-clean-all";
+  version = "0.6.4";
+
+  src = fetchFromGitHub {
+    owner = "dnlmlr";
+    repo = "cargo-clean-all";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-kSFshEoys0MjON3I70xPb7VEwmK4ne0ZsaLwpRZfhD0=";
+  };
+
+  cargoHash = "sha256-CdfqMYOgPIwoh+1Ze6YKq7d4SQHVJ0Ac+JlSQ/6kNZ0=";
+
+  doCheck = false;
+
+  meta = {
+    description = "Recursively clean all Cargo projects in a directory that match the selected criteria";
+    homepage = "https://github.com/dnlmlr/cargo-clean-all";
+    license = lib.licenses.mit;
+    mainProgram = "cargo-clean-all";
+    tags = [
+      "cli"
+      "dev-tool"
+      "rust"
+    ];
+  };
+})

--- a/readme.md
+++ b/readme.md
@@ -15,6 +15,7 @@ Additional Nix packages not yet available in [nixpkgs](https://github.com/NixOS/
 | [agave-2_2](#agave)                                   | <!-- {~v_agave_2_2:"{{ v.agave_2_2 }}"} -->2.2.20<!-- {/v_agave_2_2} -->                                             | linux (x64), macos       | Agave pinned to the latest 2.2.x release                                      |
 | [agave-2_1](#agave)                                   | <!-- {~v_agave_2_1:"{{ v.agave_2_1 }}"} -->2.1.21<!-- {/v_agave_2_1} -->                                             | linux (x64), macos       | Agave pinned to the latest 2.1.x release                                      |
 | [agave-2_0](#agave)                                   | <!-- {~v_agave_2_0:"{{ v.agave_2_0 }}"} -->2.0.25<!-- {/v_agave_2_0} -->                                             | linux (x64), macos       | Agave pinned to the latest 2.0.x release                                      |
+| [cargo-clean-all](#cargo-clean-all)                   | <!-- {~v_cargo_clean_all:"{{ v.cargo_clean_all }}"} -->0.6.4<!-- {/v_cargo_clean_all} -->                            | linux, macos             | Recursively clean Cargo projects in a directory that match selected criteria  |
 | [cargo-dylint](#cargo-dylint)                         | <!-- {~v_cargo_dylint:"{{ v.cargo_dylint }}"} -->5.0.0<!-- {/v_cargo_dylint} -->                                     | linux, macos             | A cargo extension for running Rust lints from dynamic libraries               |
 | [cargo-interactive-update](#cargo-interactive-update) | <!-- {~v_cargo_interactive_update:"{{ v.cargo_interactive_update }}"} -->0.6.2<!-- {/v_cargo_interactive_update} --> | linux, macos             | A cargo extension to update direct dependencies interactively                 |
 | [codex-cli](#codex-cli)                               | <!-- {~v_codex_cli:"{{ v.codex_cli }}"} -->0.124.0<!-- {/v_codex_cli} -->                                            | linux, macos             | OpenAI Codex CLI - AI coding assistant for the terminal                       |
@@ -234,6 +235,14 @@ nix run github:ifiokjr/nixpkgs#agave -- --version
 nix run github:ifiokjr/nixpkgs#agave-3_0 -- --version
 nix run github:ifiokjr/nixpkgs#agave-2_1 -- --version
 ```
+
+### cargo-clean-all
+
+Recursively clean Cargo projects in a directory based on filters like project age, target size, ignored paths, and interactive selection. Built from source using `rustPlatform.buildRustPackage`.
+
+- **Binary:** `cargo-clean-all`
+- **License:** MIT
+- **Source:** <https://github.com/dnlmlr/cargo-clean-all>
 
 ### cargo-dylint
 
@@ -463,7 +472,7 @@ The script updates:
 - GitHub release packages (version + platform hashes)
 - Homebrew-cask packages (`gpg-suite`, `nordvpn`, `zoom`)
 - Rolling URL packages (`steam`)
-- Rust packages built from source (`cargo-dylint`, `cargo-interactive-update`, `dylint-link`, `knope`, `pina`)
+- Rust packages built from source (`cargo-clean-all`, `cargo-dylint`, `cargo-interactive-update`, `dylint-link`, `knope`, `pina`)
 
 ### binary packages (pre-built)
 

--- a/scripts/update
+++ b/scripts/update
@@ -6,7 +6,7 @@
 # - Versioned GitHub release packages (agave, codex-cli, godot, mdt, monochange, ollama, surfpool, etc.)
 # - Homebrew-cask versioned packages (gpg-suite, nordvpn, zoom)
 # - Rolling URL packages (steam)
-# - Rust packages built from source (cargo-dylint, cargo-interactive-update, dylint-link, knope, pina)
+# - Rust packages built from source (cargo-clean-all, cargo-dylint, cargo-interactive-update, dylint-link, knope, pina)
 
 # ANSI helpers
 
@@ -930,6 +930,13 @@ def update-rust-cargo-dylint [packages_dir: string, dry_run: bool] {
   update-rust-cargo-lock-package $packages_dir "cargo-dylint" $latest_version $rev "trailofbits" "dylint" $dry_run
 }
 
+def update-rust-cargo-clean-all [repo_root: string, packages_dir: string, dry_run: bool] {
+  let tag = (github-latest-tag "dnlmlr" "cargo-clean-all")
+  let latest_version = ($tag | str replace --regex '^v' '')
+  let rev = $"v($latest_version)"
+  update-rust-package $repo_root $packages_dir "cargo-clean-all" $latest_version $rev "dnlmlr" "cargo-clean-all" $dry_run
+}
+
 def update-rust-cargo-interactive [repo_root: string, packages_dir: string, dry_run: bool] {
   let tag = (github-latest-tag "benjeau" "cargo-interactive-update")
   let latest_version = ($tag | str replace --regex '^v' '')
@@ -1099,6 +1106,7 @@ def main [
     { name: "agave-3_0", run: {|| update-agave-3-0 $packages_dir $dry_run } }
     { name: "agave-3_1", run: {|| update-agave-3-1 $packages_dir $dry_run } }
     { name: "agave-4_0", run: {|| update-agave-4-0 $packages_dir $dry_run } }
+    { name: "cargo-clean-all", run: {|| update-rust-cargo-clean-all $root $packages_dir $dry_run } }
     { name: "cargo-dylint", run: {|| update-rust-cargo-dylint $packages_dir $dry_run } }
     { name: "cargo-interactive-update", run: {|| update-rust-cargo-interactive $root $packages_dir $dry_run } }
     { name: "codex-cli", run: {|| update-codex $packages_dir $dry_run } }


### PR DESCRIPTION
## Summary
- add the `cargo-clean-all` Rust package at version `0.6.4`
- expose it through the flake outputs and overlay
- document it in `readme.md` and wire it into `scripts/update`

## Validation
- `nix build .#cargo-clean-all`
- `nix run .#cargo-clean-all -- --version`
