### PR TITLE
feat(deno): add deno binary release package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ jobs:
       - name: 🔍 detect changed packages
         id: changes
         run: |
-          LINUX_PACKAGES="agave agave-2_0 agave-2_1 agave-2_2 agave-2_3 agave-3_0 agave-3_1 cargo-interactive-update codex-cli dylint godot knope mdt monochange ollama pina pnpm pnpm-10 pnpm-11 pnpm-standalone racket-minimal surfpool wait-for-them"
-          MACOS_PACKAGES="agave agave-2_0 agave-2_1 agave-2_2 agave-2_3 agave-3_0 agave-3_1 cargo-interactive-update codex-cli dylint godot gpg-suite knope mdt monochange nordvpn ollama pina pnpm pnpm-10 pnpm-11 pnpm-standalone racket-minimal steam surfpool zoom"
+          LINUX_PACKAGES="agave agave-2_0 agave-2_1 agave-2_2 agave-2_3 agave-3_0 agave-3_1 cargo-interactive-update codex-cli deno dylint godot knope mdt monochange ollama pina pnpm pnpm-10 pnpm-11 pnpm-standalone racket-minimal surfpool wait-for-them"
+          MACOS_PACKAGES="agave agave-2_0 agave-2_1 agave-2_2 agave-2_3 agave-3_0 agave-3_1 cargo-interactive-update codex-cli deno dylint godot gpg-suite knope mdt monochange nordvpn ollama pina pnpm pnpm-10 pnpm-11 pnpm-standalone racket-minimal steam surfpool zoom"
 
           build_all=false
 

--- a/flake.nix
+++ b/flake.nix
@@ -26,6 +26,7 @@
         dylint = final.callPackage ./packages/dylint/package.nix { };
         cargo-interactive-update = final.callPackage ./packages/cargo-interactive-update/package.nix { };
         codex-cli = final.callPackage ./packages/codex-cli/package.nix { };
+        deno = final.callPackage ./packages/deno/package.nix { };
         godot = final.callPackage ./packages/godot/package.nix { };
         gpg-suite = final.callPackage ./packages/gpg-suite/package.nix { };
         kani = final.callPackage ./packages/kani/package.nix { };
@@ -70,6 +71,7 @@
           dylint = pkgs.callPackage ./packages/dylint/package.nix { };
           cargo-interactive-update = pkgs.callPackage ./packages/cargo-interactive-update/package.nix { };
           codex-cli = pkgs.callPackage ./packages/codex-cli/package.nix { };
+          deno = pkgs.callPackage ./packages/deno/package.nix { };
           godot = pkgs.callPackage ./packages/godot/package.nix { };
           gpg-suite = pkgs.callPackage ./packages/gpg-suite/package.nix { };
           kani = pkgs.callPackage ./packages/kani/package.nix { };

--- a/mdt.toml
+++ b/mdt.toml
@@ -11,6 +11,7 @@ v = { command = "./scripts/versions", format = "json", watch = [
 	"packages/dylint/package.nix",
 	"packages/cargo-interactive-update/package.nix",
 	"packages/codex-cli/package.nix",
+	"packages/deno/package.nix",
 	"packages/godot/package.nix",
 	"packages/gpg-suite/package.nix",
 	"packages/kani/package.nix",

--- a/packages/deno/package.nix
+++ b/packages/deno/package.nix
@@ -1,0 +1,76 @@
+{
+  stdenv,
+  fetchurl,
+  unzip,
+  autoPatchelfHook,
+  lib,
+}:
+
+let
+  version = "2.7.14";
+  tag = "v${version}";
+
+  platformSuffix =
+    {
+      "aarch64-darwin" = "aarch64-apple-darwin";
+      "x86_64-darwin" = "x86_64-apple-darwin";
+      "aarch64-linux" = "aarch64-unknown-linux-gnu";
+      "x86_64-linux" = "x86_64-unknown-linux-gnu";
+    }
+    .${stdenv.hostPlatform.system} or (throw "Unsupported platform: ${stdenv.hostPlatform.system}");
+
+  hashes = {
+    "aarch64-apple-darwin" = "sha256-rrWCX4O0qc1/k1WhxN3WZiBdrPdsy3uYwrEOBmvJ5Ls=";
+    "x86_64-apple-darwin" = "sha256-yJFJUTv46Cq1s1HaxUT4wMrakHU70vV29GMl+2eZeuE=";
+    "aarch64-unknown-linux-gnu" = "sha256-uBXJGUUrWZOnwi3wGKiML3Bu6mteCqeAKysHCe3eAeg=";
+    "x86_64-unknown-linux-gnu" = "sha256-Mofv71NgaWZGnLagJ4Eye+IrkIlZOX+XbimW3Btkrg8=";
+  };
+in
+stdenv.mkDerivation {
+  pname = "deno";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://github.com/denoland/deno/releases/download/${tag}/deno-${platformSuffix}.zip";
+    sha256 = hashes.${platformSuffix} or lib.fakeSha256;
+  };
+
+  dontBuild = true;
+  dontStrip = true;
+
+  nativeBuildInputs = [ unzip ] ++ lib.optionals stdenv.isLinux [ autoPatchelfHook ];
+  buildInputs = lib.optionals stdenv.isLinux [ stdenv.cc.cc.lib ];
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp deno $out/bin/deno
+    chmod +x $out/bin/deno
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A modern runtime for JavaScript and TypeScript";
+    homepage = "https://deno.com/";
+    license = licenses.mit;
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+    maintainers = [ ];
+    sourceProvenance = [ sourceTypes.binaryNativeCode ];
+    mainProgram = "deno";
+    tags = [
+      "cli"
+      "javascript"
+      "typescript"
+      "runtime"
+    ];
+  };
+}

--- a/readme.md
+++ b/readme.md
@@ -19,6 +19,7 @@ Additional Nix packages not yet available in [nixpkgs](https://github.com/NixOS/
 | [cargo-clean-all](#cargo-clean-all)                   | <!-- {~v_cargo_clean_all:"{{ v.cargo_clean_all }}"} -->0.6.4<!-- {/v_cargo_clean_all} -->                            | linux, macos               | Recursively clean Cargo projects in a directory that match selected criteria  |
 | [cargo-interactive-update](#cargo-interactive-update) | <!-- {~v_cargo_interactive_update:"{{ v.cargo_interactive_update }}"} -->0.6.2<!-- {/v_cargo_interactive_update} --> | linux, macos               | A cargo extension to update direct dependencies interactively                 |
 | [codex-cli](#codex-cli)                               | <!-- {~v_codex_cli:"{{ v.codex_cli }}"} -->0.125.0<!-- {/v_codex_cli} -->                                            | linux, macos               | OpenAI Codex CLI - AI coding assistant for the terminal                       |
+| [deno](#deno)                                         | <!-- {~v_deno:"{{ v.deno }}"} -->2.7.14<!-- {/v_deno} -->                                                            | linux, macos               | A modern runtime for JavaScript and TypeScript                                |
 | [dylint](#dylint)                                     | <!-- {~v_dylint:"{{ v.dylint }}"} -->5.0.0<!-- {/v_dylint} -->                                                       | linux, macos               | Dylint tools for running Rust lints and building Dylint libraries             |
 | [godot](#godot)                                       | <!-- {~v_godot:"{{ v.godot }}"} -->4.6.2-stable<!-- {/v_godot} -->                                                   | linux, macos               | Free and open-source 2D and 3D game engine                                    |
 | [gpg-suite](#gpg-suite)                               | <!-- {~v_gpg_suite:"{{ v.gpg_suite }}"} -->2023.3<!-- {/v_gpg_suite} -->                                             | macos                      | GPG Suite - encryption, signing, and key management                           |
@@ -48,6 +49,7 @@ nix run github:ifiokjr/nixpkgs#mdt
 nix run github:ifiokjr/nixpkgs#monochange
 nix run github:ifiokjr/nixpkgs#pnpm-standalone
 nix run github:ifiokjr/nixpkgs#codex-cli
+nix run github:ifiokjr/nixpkgs#deno
 nix run github:ifiokjr/nixpkgs#godot
 nix run github:ifiokjr/nixpkgs#ollama
 ```
@@ -261,6 +263,15 @@ OpenAI Codex CLI for AI-assisted coding directly from the terminal. Pre-built bi
 - **Binary:** `codex`
 - **License:** Apache-2.0
 - **Source:** <https://github.com/openai/codex>
+
+### deno
+
+A modern runtime for JavaScript and TypeScript. Installs the official pre-built binary from Deno GitHub releases instead of building from Rust source.
+
+- **Binary:** `deno`
+- **License:** MIT
+- **Source:** <https://github.com/denoland/deno>
+- **Homepage:** <https://deno.com/>
 
 ### dylint
 

--- a/scripts/update
+++ b/scripts/update
@@ -3,7 +3,7 @@
 #
 # The script covers:
 # - Flake inputs (nix flake update → flake.lock)
-# - Versioned GitHub release packages (agave, codex-cli, godot, kani, mdt, monochange, ollama, solana-verify, surfpool, etc.)
+# - Versioned GitHub release packages (agave, codex-cli, deno, godot, kani, mdt, monochange, ollama, solana-verify, surfpool, etc.)
 # - Homebrew-cask versioned packages (gpg-suite, nordvpn, zoom)
 # - Rolling URL packages (steam)
 # - Rust packages built from source (cargo-clean-all, cargo-interactive-update, dylint, knope, pina, sbpf-linker)
@@ -692,6 +692,17 @@ def update-codex [packages_dir: string, dry_run: bool] {
   update-versioned-keyed-hashes "codex-cli" $file $latest_version $entries $dry_run
 }
 
+def update-deno [packages_dir: string, dry_run: bool] {
+  let latest_version = (github-latest-tag "denoland" "deno" | str replace --regex '^v' '')
+  let file = $"($packages_dir)/deno/package.nix"
+  let entries = [
+    { key: "aarch64-apple-darwin", url: $"https://github.com/denoland/deno/releases/download/v($latest_version)/deno-aarch64-apple-darwin.zip" }
+    { key: "x86_64-apple-darwin", url: $"https://github.com/denoland/deno/releases/download/v($latest_version)/deno-x86_64-apple-darwin.zip" }
+    { key: "aarch64-unknown-linux-gnu", url: $"https://github.com/denoland/deno/releases/download/v($latest_version)/deno-aarch64-unknown-linux-gnu.zip" }
+    { key: "x86_64-unknown-linux-gnu", url: $"https://github.com/denoland/deno/releases/download/v($latest_version)/deno-x86_64-unknown-linux-gnu.zip" }
+  ]
+  update-versioned-keyed-hashes "deno" $file $latest_version $entries $dry_run
+}
 
 def update-godot [packages_dir: string, dry_run: bool] {
   let latest_version = (godot-latest-stable-tag)
@@ -1228,6 +1239,7 @@ def main [
     { name: "cargo-clean-all", run: {|| update-rust-cargo-clean-all $root $packages_dir $dry_run } }
     { name: "cargo-interactive-update", run: {|| update-rust-cargo-interactive $root $packages_dir $dry_run } }
     { name: "codex-cli", run: {|| update-codex $packages_dir $dry_run } }
+    { name: "deno", run: {|| update-deno $packages_dir $dry_run } }
     { name: "dylint", run: {|| update-rust-dylint $packages_dir $dry_run } }
     { name: "godot", run: {|| update-godot $packages_dir $dry_run } }
     { name: "gpg-suite", run: {|| update-gpg-suite $packages_dir $dry_run } }


### PR DESCRIPTION
Add a package for `deno` using the official pre-built binaries from GitHub releases rather than building from Rust source.

### Changes
- `packages/deno/package.nix` — new package definition (v2.7.14)
- `flake.nix` — register `deno` in overlay and per-system packages
- `.github/workflows/ci.yml` — add `deno` to Linux and macOS CI package lists
- `scripts/update` — add `update-deno` function wired into the updater
- `readme.md` — add row in the version table and dedicated package section
- `mdt.toml` — add `packages/deno/package.nix` to version watch list