### PR TITLE
feat(cargo-clean-all,pina): switch to prebuilt binaries

### DIFF
--- a/packages/cargo-clean-all/package.nix
+++ b/packages/cargo-clean-all/package.nix
@@ -1,33 +1,66 @@
 {
   lib,
-  rustPlatform,
-  fetchFromGitHub,
+  stdenv,
+  fetchurl,
 }:
 
-rustPlatform.buildRustPackage (finalAttrs: {
-  pname = "cargo-clean-all";
+let
   version = "0.6.4";
 
-  src = fetchFromGitHub {
-    owner = "dnlmlr";
-    repo = "cargo-clean-all";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-kSFshEoys0MjON3I70xPb7VEwmK4ne0ZsaLwpRZfhD0=";
+  platformSuffix =
+    {
+      "aarch64-darwin" = "aarch64-apple-darwin";
+      "x86_64-darwin" = "x86_64-apple-darwin";
+      "aarch64-linux" = "aarch64-unknown-linux-gnu";
+      "x86_64-linux" = "x86_64-unknown-linux-gnu";
+    }
+    .${stdenv.hostPlatform.system} or (throw "Unsupported platform: ${stdenv.hostPlatform.system}");
+
+  hashes = {
+    "aarch64-apple-darwin" = "sha256-L89hR3sJmQpKsw+9NxqhguBusEcbPL2Ox3WETzv1kmA=";
+    "x86_64-apple-darwin" = "sha256-ZsE/h1sJAfaAtgTxqS8E7w9lN5IWr88DVzlc8POKg0Y=";
+    "x86_64-unknown-linux-gnu" = "sha256-F/7bVv6/hkuf0QNYTWRwUFcU/fpu2DQJU/3cA8QQgBM=";
+  };
+in
+stdenv.mkDerivation {
+  pname = "cargo-clean-all";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://github.com/ifiokjr/nixpkgs/releases/download/prebuilt/cargo-clean-all/${version}/cargo-clean-all-${platformSuffix}.tar.gz";
+    hash = hashes.${platformSuffix} or lib.fakeHash;
   };
 
-  cargoHash = "sha256-CdfqMYOgPIwoh+1Ze6YKq7d4SQHVJ0Ac+JlSQ/6kNZ0=";
+  dontUnpack = true;
+  dontBuild = true;
+  dontStrip = true;
 
-  doCheck = false;
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    tar xzf $src -C $out/bin/
+    chmod +x $out/bin/cargo-clean-all
+
+    runHook postInstall
+  '';
 
   meta = {
     description = "Recursively clean all Cargo projects in a directory that match the selected criteria";
     homepage = "https://github.com/dnlmlr/cargo-clean-all";
     license = lib.licenses.mit;
     mainProgram = "cargo-clean-all";
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
     tags = [
       "cli"
       "dev-tool"
       "rust"
     ];
   };
-})
+}

--- a/packages/pina/package.nix
+++ b/packages/pina/package.nix
@@ -1,37 +1,66 @@
 {
   lib,
-  rustPlatform,
-  fetchFromGitHub,
+  stdenv,
+  fetchurl,
 }:
 
-rustPlatform.buildRustPackage (finalAttrs: {
-  pname = "pina";
+let
   version = "0.8.0";
 
-  src = fetchFromGitHub {
-    owner = "pina-rs";
-    repo = "pina";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-srg1y6XwjNjr75tVOtb7vM8HIInzk6ka0+Vn88mqZwM=";
+  platformSuffix =
+    {
+      "aarch64-darwin" = "aarch64-apple-darwin";
+      "x86_64-darwin" = "x86_64-apple-darwin";
+      "aarch64-linux" = "aarch64-unknown-linux-gnu";
+      "x86_64-linux" = "x86_64-unknown-linux-gnu";
+    }
+    .${stdenv.hostPlatform.system} or (throw "Unsupported platform: ${stdenv.hostPlatform.system}");
+
+  hashes = {
+    "aarch64-apple-darwin" = "sha256-YFxJB63Ze+i38cqssm487+yT1qhJZr/5GTYy6VKcSBI=";
+    "x86_64-apple-darwin" = "sha256-B763ofTJc8Si/bYkhvhxaYBH21pOr9OsJKgTvDcZV70=";
+    "x86_64-unknown-linux-gnu" = "sha256-4ndk7oEPB5Ee1jrqESfzCtd+isNEoWDcVCHSjzw/Iq4=";
+  };
+in
+stdenv.mkDerivation {
+  pname = "pina";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://github.com/ifiokjr/nixpkgs/releases/download/prebuilt/pina/${version}/pina-${platformSuffix}.tar.gz";
+    hash = hashes.${platformSuffix} or lib.fakeHash;
   };
 
-  cargoLock = {
-    lockFile = "${finalAttrs.src}/Cargo.lock";
-  };
+  dontUnpack = true;
+  dontBuild = true;
+  dontStrip = true;
 
-  buildAndTestSubdir = "crates/pina_cli";
+  installPhase = ''
+    runHook preInstall
 
-  doCheck = false;
+    mkdir -p $out/bin
+    tar xzf $src -C $out/bin/
+    chmod +x $out/bin/pina
+
+    runHook postInstall
+  '';
 
   meta = {
     description = "CLI for Pina, a performant Solana smart contract framework";
     homepage = "https://pina.rs";
     license = lib.licenses.asl20;
     mainProgram = "pina";
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
     tags = [
       "cli"
       "dev-tool"
       "solana"
     ];
   };
-})
+}


### PR DESCRIPTION
Switch from Rust source builds to prebuilt binaries from GitHub releases.

**Build time improvement:**
- cargo-clean-all: ~2s (was ~3 min)
- pina: ~2s (was ~4 min)

**Platforms:** aarch64-darwin, x86_64-darwin, x86_64-linux

Binaries are hosted at: https://github.com/ifiokjr/nixpkgs/releases