### PR TITLE
ci: add downstream pnpm tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,6 +181,61 @@ jobs:
       - name: 🏗️ build ${{ matrix.package }}
         run: nix build .#${{ matrix.package }}
 
+  downstream:
+    name: "downstream ${{ matrix.project }}"
+    needs: [detect-changes, validate, test-update-script]
+    if: contains(needs.detect-changes.outputs.linux-packages, 'pnpm') || contains(needs.detect-changes.outputs.macos-packages, 'pnpm') || github.event_name == 'push'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - project: monochange
+            repository: monochange/monochange
+            command: pnpm install --frozen-lockfile
+    steps:
+      - name: 📥 checkout repository
+        uses: actions/checkout@v4
+
+      - name: 🔧 install nix
+        uses: DeterminateSystems/nix-installer-action@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 🔧 set up nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
+
+      - name: 📥 checkout downstream ${{ matrix.project }}
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ matrix.repository }}
+          path: downstream/${{ matrix.project }}
+
+      - name: 🧪 test downstream ${{ matrix.project }}
+        working-directory: downstream/${{ matrix.project }}
+        run: |
+          set -euo pipefail
+          export XDG_DATA_HOME="$PWD/.xdg-data"
+          export XDG_CACHE_HOME="$PWD/.xdg-cache"
+          mkdir -p "$XDG_DATA_HOME" "$XDG_CACHE_HOME"
+
+          python3 - <<'PY'
+          from pathlib import Path
+
+          path = Path("devenv.yaml")
+          text = path.read_text()
+          text = text.replace("url: github:ifiokjr/nixpkgs", f"url: path:{Path.cwd().parents[1]}")
+          path.write_text(text)
+          PY
+
+          nix shell nixpkgs#devenv -c devenv update ifiokjr-nixpkgs
+          nix shell nixpkgs#devenv -c env \
+            HOME=/homeless-shelter \
+            PNPM_HOME="$XDG_DATA_HOME/pnpm" \
+            XDG_CACHE_HOME="$PWD/.xdg-cache" \
+            XDG_DATA_HOME="$XDG_DATA_HOME" \
+            devenv shell ${{ matrix.command }}
+
   build-macos:
     name: "build ${{ matrix.package }} (macos)"
     needs: [detect-changes, validate, test-update-script]

--- a/packages/pina/package.nix
+++ b/packages/pina/package.nix
@@ -19,7 +19,7 @@ let
   hashes = {
     "aarch64-apple-darwin" = "sha256-YFxJB63Ze+i38cqssm487+yT1qhJZr/5GTYy6VKcSBI=";
     "x86_64-apple-darwin" = "sha256-B763ofTJc8Si/bYkhvhxaYBH21pOr9OsJKgTvDcZV70=";
-    "x86_64-unknown-linux-gnu" = "sha256-4ndk7oEPB5Ee1jrqESfzCtd+isNEoWDcVCHSjzw/Iq4=";
+    "x86_64-unknown-linux-gnu" = "sha256-+iGFrClE5MMvSsc3GG5EQvg1mn/XNU7hzjGI6dUwJSw=";
   };
 in
 stdenv.mkDerivation {

--- a/packages/pnpm/common.nix
+++ b/packages/pnpm/common.nix
@@ -234,7 +234,7 @@ stdenv.mkDerivation {
 
         case "''${1-} ''${2-} ''${3-}" in
           "bin -g ")
-            printf '%s\n' "$effective_pnpm_home"
+            printf '%s\n' "''${TEST_FAKE_GLOBAL_BIN:-$effective_pnpm_home}"
             ;;
           "env add --global")
             version="''${4:?missing version}"
@@ -265,6 +265,38 @@ stdenv.mkDerivation {
           test -n "$EXPORTS"
           eval "$EXPORTS"
           test "$PNPM_HOME" = "$TEST_PNPM_HOME"
+        )
+
+        mkdir -p "$TEST_ROOT/homeless-home/ws"
+        cat > "$TEST_ROOT/homeless-home/ws/pnpm-workspace.yaml" <<'EOF'
+        useNodeVersion: "20.11.1"
+        EOF
+
+        (
+          cd "$TEST_ROOT/homeless-home/ws"
+          export PNPM_ACTIVATE_PNPM_BIN="$FAKE_PNPM"
+          export TEST_FAKE_GLOBAL_BIN="/homeless-shelter/.local/share/pnpm"
+          export TEST_LOG
+          export HOME="/homeless-shelter"
+          export XDG_DATA_HOME="$TEST_ROOT/xdg-data"
+          unset PNPM_HOME
+          EXPORTS="$($out/bin/pnpm-activate-env)"
+          test -n "$EXPORTS"
+          eval "$EXPORTS"
+          test "$PNPM_HOME" = "$XDG_DATA_HOME/pnpm"
+        )
+
+        (
+          cd "$TEST_ROOT/homeless-home/ws"
+          export PNPM_ACTIVATE_PNPM_BIN="$FAKE_PNPM"
+          export TEST_FAKE_GLOBAL_BIN="/homeless-shelter/.local/share/pnpm"
+          export TEST_LOG
+          export HOME="/homeless-shelter"
+          unset XDG_DATA_HOME PNPM_HOME
+          EXPORTS="$($out/bin/pnpm-activate-env)"
+          test -n "$EXPORTS"
+          eval "$EXPORTS"
+          test "$PNPM_HOME" = "$PWD/.pnpm-home"
         )
 
         mkdir -p "$TEST_ROOT/no-workspace"
@@ -304,6 +336,13 @@ stdenv.mkDerivation {
           EXPORTS="$($out/bin/pnpm-activate-env)"
           test -n "$EXPORTS"
           eval "$EXPORTS"
+          case "$PATH" in
+            "$TEST_PNPM_HOME:"*) ;;
+            *)
+              echo "pnpm-activate-env did not prioritize PNPM_HOME on PATH" >&2
+              exit 1
+              ;;
+          esac
           case ":$PATH:" in
             *":$TEST_PNPM_HOME/nodejs/20.11.1/bin:") ;;
             *)

--- a/packages/pnpm/pnpm-activate-env.sh
+++ b/packages/pnpm/pnpm-activate-env.sh
@@ -163,7 +163,22 @@ resolve_pnpm_home() {
 	global_bin="$(trim "$global_bin")"
 
 	if [ -n "$global_bin" ] && [ "$global_bin" != "undefined" ]; then
-		printf '%s\n' "$global_bin"
+		case "$global_bin" in
+		/homeless-shelter | /homeless-shelter/*) ;;
+		*)
+			printf '%s\n' "$global_bin"
+			return 0
+			;;
+		esac
+	fi
+
+	if [ -n "${XDG_DATA_HOME:-}" ]; then
+		printf '%s\n' "${XDG_DATA_HOME}/pnpm"
+		return 0
+	fi
+
+	if [ "${HOME:-}" = "/homeless-shelter" ]; then
+		printf '%s\n' "${PWD}/.pnpm-home"
 		return 0
 	fi
 
@@ -193,12 +208,12 @@ emit_export_script() {
 	cat <<'EOF'
 export PNPM_HOME="${__pnpm_activate_pnpm_home}"
 case ":$PATH:" in
-  *":${__pnpm_activate_pnpm_home}:"*) ;;
-  *) export PATH="${__pnpm_activate_pnpm_home}:$PATH" ;;
-esac
-case ":$PATH:" in
   *":${__pnpm_activate_node_bin}:"*) ;;
   *) export PATH="${__pnpm_activate_node_bin}:$PATH" ;;
+esac
+case ":$PATH:" in
+  *":${__pnpm_activate_pnpm_home}:"*) ;;
+  *) export PATH="${__pnpm_activate_pnpm_home}:$PATH" ;;
 esac
 unset __pnpm_activate_pnpm_home __pnpm_activate_node_bin
 EOF
@@ -210,12 +225,12 @@ apply_path() {
 
 	export PNPM_HOME="$pnpm_home"
 
-	if ! path_has_entry "$PATH" "$pnpm_home"; then
-		export PATH="${pnpm_home}:$PATH"
-	fi
-
 	if ! path_has_entry "$PATH" "$node_bin"; then
 		export PATH="${node_bin}:$PATH"
+	fi
+
+	if ! path_has_entry "$PATH" "$pnpm_home"; then
+		export PATH="${pnpm_home}:$PATH"
 	fi
 }
 


### PR DESCRIPTION
## Summary
- add a downstream CI job for PNPM-sensitive packages
- clone monochange/monochange and run its devenv PNPM install workflow against this repo checkout
- simulate pure Nix/devenv CI with HOME=/homeless-shelter plus writable XDG cache/data dirs
- tighten pnpm-activate-env so PNPM_HOME falls back to XDG_DATA_HOME when pnpm reports a /homeless-shelter global bin

## Test
- dprint fmt
- nix build .#pnpm --no-link

Note: I am not merging this PR automatically per request.