### PR TITLE
feat(ironclaw): add ironclaw v0.28.2 package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -29,6 +29,7 @@
         deno = final.callPackage ./packages/deno/package.nix { };
         godot = final.callPackage ./packages/godot/package.nix { };
         gpg-suite = final.callPackage ./packages/gpg-suite/package.nix { };
+        ironclaw = final.callPackage ./packages/ironclaw/package.nix { };
         kani = final.callPackage ./packages/kani/package.nix { };
         knope = final.callPackage ./packages/knope/package.nix { };
         mdt = final.callPackage ./packages/mdt/package.nix { };
@@ -74,6 +75,7 @@
           deno = pkgs.callPackage ./packages/deno/package.nix { };
           godot = pkgs.callPackage ./packages/godot/package.nix { };
           gpg-suite = pkgs.callPackage ./packages/gpg-suite/package.nix { };
+          ironclaw = pkgs.callPackage ./packages/ironclaw/package.nix { };
           kani = pkgs.callPackage ./packages/kani/package.nix { };
           knope = pkgs.callPackage ./packages/knope/package.nix { };
           mdt = pkgs.callPackage ./packages/mdt/package.nix { };

--- a/packages/ironclaw/package.nix
+++ b/packages/ironclaw/package.nix
@@ -36,14 +36,11 @@ stdenv.mkDerivation {
   dontBuild = true;
   dontStrip = stdenv.isDarwin;
 
-  sourceRoot = ".";
-
   installPhase = ''
     runHook preInstall
 
     mkdir -p $out/bin
-    cp ironclaw-${platformSuffix}/ironclaw $out/bin/ironclaw
-    chmod +x $out/bin/ironclaw
+    install -m 755 ironclaw $out/bin/ironclaw
 
     runHook postInstall
   '';

--- a/packages/ironclaw/package.nix
+++ b/packages/ironclaw/package.nix
@@ -1,0 +1,68 @@
+{
+  stdenv,
+  fetchurl,
+  lib,
+}:
+
+let
+  version = "0.28.2";
+  tag = "ironclaw-v${version}";
+
+  platformSuffix =
+    {
+      "aarch64-darwin" = "aarch64-apple-darwin";
+      "x86_64-darwin" = "x86_64-apple-darwin";
+      "aarch64-linux" = "aarch64-unknown-linux-gnu";
+      "x86_64-linux" = "x86_64-unknown-linux-musl";
+    }
+    .${stdenv.hostPlatform.system} or (throw "Unsupported platform: ${stdenv.hostPlatform.system}");
+
+  hashes = {
+    "aarch64-apple-darwin" = "sha256-DnKCuEaQ684J421S3xICYskHX8inuHaSx6YCGtCCGC4=";
+    "x86_64-apple-darwin" = "sha256-BhN6ZX445ULdJCEbm+kPssREnPeFBcDloBJdZzI+gVI=";
+    "aarch64-unknown-linux-gnu" = "sha256-PtJcmIekFIXsSVpTSUgll5ZtA8Xtlw1n9DP+FSNmjI8=";
+    "x86_64-unknown-linux-musl" = "sha256-yyKNpVxct9yzhzi2czAgZF1JyHhoFk8S+oSA4zODR3Q=";
+  };
+in
+stdenv.mkDerivation {
+  pname = "ironclaw";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://github.com/nearai/ironclaw/releases/download/${tag}/ironclaw-${platformSuffix}.tar.gz";
+    sha256 = hashes.${platformSuffix} or lib.fakeSha256;
+  };
+
+  dontBuild = true;
+  dontStrip = stdenv.isDarwin;
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp ironclaw-${platformSuffix}/ironclaw $out/bin/ironclaw
+    chmod +x $out/bin/ironclaw
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "AI-powered coding agent with mission orchestration, WASM tools, and multi-channel support";
+    homepage = "https://github.com/nearai/ironclaw";
+    license = lib.licenses.asl20;
+    mainProgram = "ironclaw";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+    tags = [
+      "cli"
+      "dev-tool"
+      "ai"
+    ];
+  };
+}

--- a/scripts/update
+++ b/scripts/update
@@ -1032,6 +1032,19 @@ def update-rust-knope [repo_root: string, packages_dir: string, dry_run: bool] {
   update-rust-package $repo_root $packages_dir "knope" $latest_version $rev "knope-dev" "knope" $dry_run
 }
 
+def update-ironclaw [packages_dir: string, dry_run: bool] {
+  let tag = (github-latest-tag-with-prefix "nearai" "ironclaw" "ironclaw-v")
+  let latest_version = ($tag | str replace --regex '^ironclaw-v' '')
+  let file = $"($packages_dir)/ironclaw/package.nix"
+  let entries = [
+    { key: "aarch64-apple-darwin", url: $"https://github.com/nearai/ironclaw/releases/download/($tag)/ironclaw-aarch64-apple-darwin.tar.gz" }
+    { key: "x86_64-apple-darwin", url: $"https://github.com/nearai/ironclaw/releases/download/($tag)/ironclaw-x86_64-apple-darwin.tar.gz" }
+    { key: "aarch64-unknown-linux-gnu", url: $"https://github.com/nearai/ironclaw/releases/download/($tag)/ironclaw-aarch64-unknown-linux-gnu.tar.gz" }
+    { key: "x86_64-unknown-linux-musl", url: $"https://github.com/nearai/ironclaw/releases/download/($tag)/ironclaw-x86_64-unknown-linux-musl.tar.gz" }
+  ]
+  update-versioned-keyed-hashes "ironclaw" $file $latest_version $entries $dry_run
+}
+
 def update-mdt [packages_dir: string, dry_run: bool] {
   let latest_version = (github-latest-tag "ifiokjr" "mdt" | str replace --regex '^v' '')
   let file = $"($packages_dir)/mdt/package.nix"
@@ -1308,6 +1321,7 @@ def main [
     { name: "dylint", run: {|| update-prebuilt-dylint $packages_dir $dry_run } }
     { name: "godot", run: {|| update-godot $packages_dir $dry_run } }
     { name: "gpg-suite", run: {|| update-gpg-suite $packages_dir $dry_run } }
+    { name: "ironclaw", run: {|| update-ironclaw $packages_dir $dry_run } }
     { name: "kani", run: {|| update-kani $packages_dir $dry_run } }
     { name: "knope", run: {|| update-rust-knope $root $packages_dir $dry_run } }
     { name: "mdt", run: {|| update-mdt $packages_dir $dry_run } }


### PR DESCRIPTION
Add ironclaw (nearai/ironclaw) as a prebuilt binary package with support for:

- aarch64-darwin
- x86_64-darwin
- aarch64-linux (gnu)
- x86_64-linux (musl)

Uses GitHub releases for fast installation. Includes update script entry in `scripts/update` that tracks the `ironclaw-v` tag prefix.