### PR TITLE
feat(op): add 1Password CLI beta

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -36,6 +36,7 @@
         monochange = final.callPackage ./packages/monochange/package.nix { };
         nordvpn = final.callPackage ./packages/nordvpn/package.nix { };
         ollama = final.callPackage ./packages/ollama/package.nix { };
+        op = final.callPackage ./packages/op/package.nix { };
         pina = final.callPackage ./packages/pina/package.nix { };
         pnpm = final.callPackage ./packages/pnpm/package.nix { };
         pnpm-10 = final.callPackage ./packages/pnpm-10/package.nix { };
@@ -82,6 +83,7 @@
           monochange = pkgs.callPackage ./packages/monochange/package.nix { };
           nordvpn = pkgs.callPackage ./packages/nordvpn/package.nix { };
           ollama = pkgs.callPackage ./packages/ollama/package.nix { };
+          op = pkgs.callPackage ./packages/op/package.nix { };
           pina = pkgs.callPackage ./packages/pina/package.nix { };
           pnpm = pkgs.callPackage ./packages/pnpm/package.nix { };
           pnpm-10 = pkgs.callPackage ./packages/pnpm-10/package.nix { };

--- a/packages/op/package.nix
+++ b/packages/op/package.nix
@@ -1,0 +1,97 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  fetchzip,
+  autoPatchelfHook,
+  installShellFiles,
+  cpio,
+  xar,
+}:
+
+let
+  version = "2.35.0-beta.01";
+
+  fetch =
+    srcPlatform: hash: extension:
+    let
+      args = {
+        url = "https://cache.agilebits.com/dist/1P/op2/pkg/v${version}/op_${srcPlatform}_v${version}.${extension}";
+        inherit hash;
+      }
+      // lib.optionalAttrs (extension == "zip") { stripRoot = false; };
+    in
+    if extension == "zip" then fetchzip args else fetchurl args;
+
+  sources = rec {
+    aarch64-linux = fetch "linux_arm64" "sha256-HlmNAnHeFvWplcIBSWHP6REbEfBTWKtzMURUrqu3Ns0=" "zip";
+    x86_64-linux = fetch "linux_amd64" "sha256-oNzlRzPPMxc3oA4UkSV/VohqzoLAo9SBxcwzqdcwW84=" "zip";
+    aarch64-darwin =
+      fetch "apple_universal" "sha256-5SA1qClHRXei64xFUrykecQO7Le5GlANHj25XCCjt2I="
+        "pkg";
+    x86_64-darwin = aarch64-darwin;
+  };
+
+  platforms = builtins.attrNames sources;
+in
+
+stdenv.mkDerivation {
+  pname = "op";
+  inherit version;
+
+  src =
+    if (builtins.elem stdenv.hostPlatform.system platforms) then
+      sources.${stdenv.hostPlatform.system}
+    else
+      throw "Source for op (1password-cli beta) is not available for ${stdenv.hostPlatform.system}";
+
+  nativeBuildInputs = [
+    installShellFiles
+  ]
+  ++ lib.optional stdenv.hostPlatform.isLinux autoPatchelfHook
+  ++ lib.optional stdenv.hostPlatform.isDarwin [
+    xar
+    cpio
+  ];
+
+  unpackPhase = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    xar -xf $src
+    zcat op.pkg/Payload | cpio -i
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -D op $out/bin/op
+    runHook postInstall
+  '';
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    HOME=$TMPDIR
+    installShellCompletion --cmd op \
+      --bash <($out/bin/op completion bash) \
+      --fish <($out/bin/op completion fish) \
+      --zsh <($out/bin/op completion zsh)
+  '';
+
+  dontStrip = stdenv.hostPlatform.isDarwin;
+
+  meta = {
+    description = "1Password CLI (beta channel) with environment support";
+    homepage = "https://developer.1password.com/docs/cli/";
+    downloadPage = "https://app-updates.agilebits.com/product_history/CLI2";
+    license = lib.licenses.unfree;
+    mainProgram = "op";
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+    tags = [
+      "cli"
+      "secrets"
+      "password-manager"
+    ];
+  };
+}

--- a/scripts/update
+++ b/scripts/update
@@ -888,7 +888,7 @@ def update-solana-verify [packages_dir: string, dry_run: bool] {
 
 def update-op [packages_dir: string, dry_run: bool] {
   let rss = (try {
-    ^curl -fsSL "https://releases.1password.com/developers/cli-beta/index.xml" | str trim
+    http get --raw "https://releases.1password.com/developers/cli-beta/index.xml"
   } catch {
     fail "Failed to fetch 1Password CLI beta RSS feed"
   })

--- a/scripts/update
+++ b/scripts/update
@@ -886,6 +886,67 @@ def update-solana-verify [packages_dir: string, dry_run: bool] {
   update-versioned-keyed-hashes "solana-verify" $file $latest_version $entries $dry_run
 }
 
+def update-op [packages_dir: string, dry_run: bool] {
+  let rss = (try {
+    http get "https://releases.1password.com/developers/cli-beta/index.xml"
+  } catch {
+    fail "Failed to fetch 1Password CLI beta RSS feed"
+  })
+  let latest_version = (
+    $rss
+    | parse --regex '<item>.*?<title>1Password CLI Beta ([^<]+)</title>'
+    | get -o capture0.0
+    | default ""
+  )
+  if ($latest_version | is-empty) {
+    fail "Could not parse latest beta version from RSS feed"
+  }
+
+  let file = $"($packages_dir)/op/package.nix"
+  if not ($file | path exists) {
+    fail $"missing file: ($file)"
+  }
+
+  let content = (open $file --raw)
+  let current_version = (parse-capture $content 'version = "([^"]+)"')
+  if ($current_version | is-empty) {
+    fail "could not parse version for op"
+  }
+
+  if $current_version == $latest_version {
+    log-ok "op" $"up to date \(v($current_version)\)"
+    return false
+  }
+
+  log-update "op" $"v($current_version) → v($latest_version)"
+  if $dry_run {
+    return true
+  }
+
+  mut updated = (replace-version $content $latest_version)
+
+  # Fetch hashes for each platform
+  let entries = [
+    { key: "linux_arm64", url: $"https://cache.agilebits.com/dist/1P/op2/pkg/v($latest_version)/op_linux_arm64_v($latest_version).zip" }
+    { key: "linux_amd64", url: $"https://cache.agilebits.com/dist/1P/op2/pkg/v($latest_version)/op_linux_amd64_v($latest_version).zip" }
+    { key: "apple_universal", url: $"https://cache.agilebits.com/dist/1P/op2/pkg/v($latest_version)/op_apple_universal_v($latest_version).pkg" }
+  ]
+  for entry in $entries {
+    log-sub $"fetching ($entry.key)..."
+    let new_hash = (prefetch-sri $entry.url)
+    # Replace the hash in: fetch "key" "old_hash" "ext"
+    let current_hash = (parse-capture $updated $"fetch \"($entry.key)\" \"([^\"]+)\"")
+    if ($current_hash | is-empty) {
+      fail $"could not find hash for ($entry.key)"
+    }
+    $updated = ($updated | str replace $"fetch \"($entry.key)\" \"($current_hash)\"" $"fetch \"($entry.key)\" \"($new_hash)\"")
+  }
+
+  $updated | save -f $file
+  log-ok "op" "updated"
+  true
+}
+
 def update-nordvpn [packages_dir: string, dry_run: bool] {
   let latest_version = (brew-cask-latest-version "nordvpn")
   let file = $"($packages_dir)/nordvpn/package.nix"
@@ -1328,6 +1389,7 @@ def main [
     { name: "monochange", run: {|| update-monochange $packages_dir $dry_run } }
     { name: "nordvpn", run: {|| update-nordvpn $packages_dir $dry_run } }
     { name: "ollama", run: {|| update-ollama $packages_dir $dry_run } }
+    { name: "op", run: {|| update-op $packages_dir $dry_run } }
     { name: "pina", run: {|| update-prebuilt-pina $packages_dir $dry_run } }
     { name: "pnpm", run: {|| update-pnpm $packages_dir $dry_run } }
     { name: "pnpm-10", run: {|| update-pnpm-10 $packages_dir $dry_run } }

--- a/scripts/update
+++ b/scripts/update
@@ -888,7 +888,7 @@ def update-solana-verify [packages_dir: string, dry_run: bool] {
 
 def update-op [packages_dir: string, dry_run: bool] {
   let rss = (try {
-    http get "https://releases.1password.com/developers/cli-beta/index.xml"
+    ^curl -fsSL "https://releases.1password.com/developers/cli-beta/index.xml" | str trim
   } catch {
     fail "Failed to fetch 1Password CLI beta RSS feed"
   })

--- a/scripts/update
+++ b/scripts/update
@@ -935,11 +935,15 @@ def update-op [packages_dir: string, dry_run: bool] {
     log-sub $"fetching ($entry.key)..."
     let new_hash = (prefetch-sri $entry.url)
     # Replace the hash in: fetch "key" "old_hash" "ext"
-    let current_hash = (parse-capture $updated $"fetch \"($entry.key)\" \"([^\"]+)\"")
+    # Use parse-capture with a pattern that matches the fetch call
+    let pattern = 'fetch "' + $entry.key + '" "(sha256-[^"]+)"'
+    let current_hash = (parse-capture $updated $pattern)
     if ($current_hash | is-empty) {
       fail $"could not find hash for ($entry.key)"
     }
-    $updated = ($updated | str replace $"fetch \"($entry.key)\" \"($current_hash)\"" $"fetch \"($entry.key)\" \"($new_hash)\"")
+    let old_fragment = 'fetch "' + $entry.key + '" "' + $current_hash + '"'
+    let new_fragment = 'fetch "' + $entry.key + '" "' + $new_hash + '"'
+    $updated = ($updated | str replace $old_fragment $new_fragment)
   }
 
   $updated | save -f $file


### PR DESCRIPTION
Adds `op` (1password-cli beta channel) as a prebuilt binary package.

The beta channel is required for:
- `op environment read` — read env vars from 1Password Environments
- `op run --environment` — load variables from 1Password Environments

These features are **not available** in the stable 1password-cli release.

Based on the upstream [nixpkgs package](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/by-name/_1/_1password-cli/package.nix) but tracks the beta channel instead.

**Platforms:** aarch64-darwin, x86_64-darwin, aarch64-linux, x86_64-linux
**Shell completions:** bash, fish, zsh
**Update script:** parses the 1Password CLI beta RSS feed for latest version