### PR TITLE
fix: update op 2.35.0-beta.01 hashes for Linux platforms

### DIFF
--- a/packages/op/package.nix
+++ b/packages/op/package.nix
@@ -24,8 +24,8 @@ let
     if extension == "zip" then fetchzip args else fetchurl args;
 
   sources = rec {
-    aarch64-linux = fetch "linux_arm64" "sha256-HlmNAnHeFvWplcIBSWHP6REbEfBTWKtzMURUrqu3Ns0=" "zip";
-    x86_64-linux = fetch "linux_amd64" "sha256-oNzlRzPPMxc3oA4UkSV/VohqzoLAo9SBxcwzqdcwW84=" "zip";
+    aarch64-linux = fetch "linux_arm64" "sha256-DH2Ze6AVk0extqMp4tyNnepseQu1YJENGwHCjFU7foY=" "zip";
+    x86_64-linux = fetch "linux_amd64" "sha256-R1O+u38bEqmAuOhyvm+Zb+xSYi32ySbXZW+EL33UJW8=" "zip";
     aarch64-darwin =
       fetch "apple_universal" "sha256-5SA1qClHRXei64xFUrykecQO7Le5GlANHj25XCCjt2I="
         "pkg";


### PR DESCRIPTION
1Password republished the `2.35.0-beta.01` binaries, causing Nix hash mismatches on both Linux platforms:

- **aarch64-linux**: `sha256-HlmNAnHeFvWplcIBSWHP6REbEfBTWKtzMURUrqu3Ns0=` → `sha256-DH2Ze6AVk0extqMp4tyNnepseQu1YJENGwHCjFU7foY=`
- **x86_64-linux**: `sha256-oNzlRzPPMxc3oA4UkSV/VohqzoLAo9SBxcwzqdcwW84=` → `sha256-R1O+u38bEqmAuOhyvm+Zb+xSYi32ySbXZW+EL33UJW8=`

The macOS (apple_universal) hash remains unchanged.

This was causing the `ci-nix` workflow to fail in the dotfiles repo.