### PR TITLE
fix(op): use fetchzip-unpacked hashes for Linux platforms

### DIFF
--- a/packages/op/package.nix
+++ b/packages/op/package.nix
@@ -24,8 +24,8 @@ let
     if extension == "zip" then fetchzip args else fetchurl args;
 
   sources = rec {
-    aarch64-linux = fetch "linux_arm64" "sha256-HlmNAnHeFvWplcIBSWHP6REbEfBTWKtzMURUrqu3Ns0=" "zip";
-    x86_64-linux = fetch "linux_amd64" "sha256-oNzlRzPPMxc3oA4UkSV/VohqzoLAo9SBxcwzqdcwW84=" "zip";
+    aarch64-linux = fetch "linux_arm64" "sha256-DH2Ze6AVk0extqMp4tyNnepseQu1YJENGwHCjFU7foY=" "zip";
+    x86_64-linux = fetch "linux_amd64" "sha256-R1O+u38bEqmAuOhyvm+Zb+xSYi32ySbXZW+EL33UJW8=" "zip";
     aarch64-darwin =
       fetch "apple_universal" "sha256-5SA1qClHRXei64xFUrykecQO7Le5GlANHj25XCCjt2I="
         "pkg";

--- a/scripts/update
+++ b/scripts/update
@@ -926,14 +926,15 @@ def update-op [packages_dir: string, dry_run: bool] {
   mut updated = (replace-version $content $latest_version)
 
   # Fetch hashes for each platform
+  # .zip files use fetchzip (unpacked hashes), .pkg uses fetchurl (raw hashes)
   let entries = [
-    { key: "linux_arm64", url: $"https://cache.agilebits.com/dist/1P/op2/pkg/v($latest_version)/op_linux_arm64_v($latest_version).zip" }
-    { key: "linux_amd64", url: $"https://cache.agilebits.com/dist/1P/op2/pkg/v($latest_version)/op_linux_amd64_v($latest_version).zip" }
-    { key: "apple_universal", url: $"https://cache.agilebits.com/dist/1P/op2/pkg/v($latest_version)/op_apple_universal_v($latest_version).pkg" }
+    { key: "linux_arm64", url: $"https://cache.agilebits.com/dist/1P/op2/pkg/v($latest_version)/op_linux_arm64_v($latest_version).zip", unpack: true }
+    { key: "linux_amd64", url: $"https://cache.agilebits.com/dist/1P/op2/pkg/v($latest_version)/op_linux_amd64_v($latest_version).zip", unpack: true }
+    { key: "apple_universal", url: $"https://cache.agilebits.com/dist/1P/op2/pkg/v($latest_version)/op_apple_universal_v($latest_version).pkg", unpack: false }
   ]
   for entry in $entries {
     log-sub $"fetching ($entry.key)..."
-    let new_hash = (prefetch-sri $entry.url)
+    let new_hash = (if $entry.unpack { prefetch-sri-unpack $entry.url } else { prefetch-sri $entry.url })
     # Replace the hash in: fetch "key" "old_hash" "ext"
     # Use parse-capture with a pattern that matches the fetch call
     let pattern = 'fetch "' + $entry.key + '" "(sha256-[^"]+)"'


### PR DESCRIPTION
The Linux  binaries use `fetchzip` which hashes the **unpacked** content, not the raw download archive. The initial package had raw-download hashes which only work for `fetchurl` (.pkg on macOS).

This fixes:
- Replaces the Linux SHA256 hashes with the correct unpacked hashes
- Updates the update script to use `prefetch-sri-unpack` for .zip entries and `prefetch-sri` for .pkg entries