### PR TITLE
feat(pnpm): add v11 runtime activation and env setup

### DIFF
--- a/packages/pnpm-11/package.nix
+++ b/packages/pnpm-11/package.nix
@@ -3,7 +3,7 @@
 callPackage ../pnpm/common.nix {
   pname = "pnpm-11";
   version = "11.0.4";
-  description = "Fast, disk space efficient package manager (standalone, no Node.js dependency) — v11 pre-release";
+  description = "Fast, disk space efficient package manager (standalone, no Node.js dependency) — v11";
   exeHash = "sha256-Vkf+hpA6Tim8eDSaPhI0Wwn1kUsMH8AAAXH6IBnWYRg=";
   hashes = {
     "x86_64-linux" = "sha256-gdUd4nPY4KVwBxcN6S0V/qBjMT7RBYmYstXWFl/7aKQ=";

--- a/packages/pnpm/common.nix
+++ b/packages/pnpm/common.nix
@@ -25,6 +25,8 @@ let
     sha256 = hashes.${stdenv.hostPlatform.system} or lib.fakeSha256;
   };
 
+  useRuntimeCommand = lib.versionAtLeast version "11";
+
   exeSrc =
     if exeHash != null then
       fetchurl {
@@ -115,6 +117,8 @@ stdenv.mkDerivation {
     done
 
     install -m 755 ${./pnpm-activate-env.sh} $out/bin/pnpm-activate-env
+    substituteInPlace $out/bin/pnpm-activate-env \
+      --replace-fail '@PNPM_ACTIVATE_USE_RUNTIME@' '${if useRuntimeCommand then "1" else "0"}'
     patchShebangs $out/bin/pnpm-activate-env
 
     mkdir -p $out/nix-support
@@ -135,10 +139,12 @@ stdenv.mkDerivation {
     fi
 
     if [ -n "''${PNPM_HOME:-}" ]; then
+      PNPM_GLOBAL_BIN="''${PNPM_HOME}${if useRuntimeCommand then "/bin" else ""}"
       case ":''${PATH:-}:" in
-        *":''${PNPM_HOME}:"*) ;;
-        *) export PATH="''${PNPM_HOME}:''${PATH:-}" ;;
+        *":''${PNPM_GLOBAL_BIN}:"*) ;;
+        *) export PATH="''${PNPM_GLOBAL_BIN}:''${PATH:-}" ;;
       esac
+      unset PNPM_GLOBAL_BIN
     fi
     EOF
 
@@ -160,6 +166,7 @@ stdenv.mkDerivation {
 
         echo "Checking PNPM_HOME setup hook..."
         SETUP_ROOT=$(mktemp -d)
+        SETUP_GLOBAL_SUFFIX="${if useRuntimeCommand then "/bin" else ""}"
         (
           export HOME="$SETUP_ROOT/home"
           export PATH="/usr/bin:/bin"
@@ -174,9 +181,9 @@ stdenv.mkDerivation {
               ;;
           esac
           case ":$PATH:" in
-            *":$PNPM_HOME:"*) ;;
+            *":$PNPM_HOME$SETUP_GLOBAL_SUFFIX:"*) ;;
             *)
-              echo "setup-hook did not add PNPM_HOME to PATH" >&2
+              echo "setup-hook did not add PNPM global bin to PATH" >&2
               exit 1
               ;;
           esac
@@ -188,9 +195,9 @@ stdenv.mkDerivation {
           . "$out/nix-support/setup-hook"
           test "$PNPM_HOME" = "$SETUP_ROOT/custom-pnpm-home"
           case ":$PATH:" in
-            *":$SETUP_ROOT/custom-pnpm-home:"*) ;;
+            *":$SETUP_ROOT/custom-pnpm-home$SETUP_GLOBAL_SUFFIX:"*) ;;
             *)
-              echo "setup-hook did not preserve and add custom PNPM_HOME to PATH" >&2
+              echo "setup-hook did not preserve and add custom PNPM global bin to PATH" >&2
               exit 1
               ;;
           esac
@@ -203,9 +210,9 @@ stdenv.mkDerivation {
           . "$out/nix-support/setup-hook"
           test "$PNPM_HOME" = "$XDG_DATA_HOME/pnpm"
           case ":$PATH:" in
-            *":$XDG_DATA_HOME/pnpm:"*) ;;
+            *":$XDG_DATA_HOME/pnpm$SETUP_GLOBAL_SUFFIX:"*) ;;
             *)
-              echo "setup-hook did not use XDG_DATA_HOME when HOME is /homeless-shelter" >&2
+              echo "setup-hook did not use XDG_DATA_HOME global bin when HOME is /homeless-shelter" >&2
               exit 1
               ;;
           esac
@@ -223,6 +230,12 @@ stdenv.mkDerivation {
         TEST_ROOT=$(mktemp -d)
         TEST_PNPM_HOME="$TEST_ROOT/pnpm-home"
         TEST_LOG="$TEST_ROOT/pnpm.log"
+        TEST_USE_RUNTIME="${if useRuntimeCommand then "1" else "0"}"
+        TEST_GLOBAL_BIN="$TEST_PNPM_HOME${if useRuntimeCommand then "/bin" else ""}"
+        TEST_NODE_BIN="$TEST_PNPM_HOME${if useRuntimeCommand then "/bin" else "/nodejs/20.11.1/bin"}"
+        TEST_INSTALL_LOG="${
+          if useRuntimeCommand then "runtime set node 20.11.1" else "env add 20.11.1"
+        }"
         : > "$TEST_LOG"
 
         FAKE_PNPM="$TEST_ROOT/fake-pnpm"
@@ -242,6 +255,15 @@ stdenv.mkDerivation {
             mkdir -p "$effective_pnpm_home/nodejs/$version/bin"
             : > "$effective_pnpm_home/nodejs/$version/bin/node"
             chmod +x "$effective_pnpm_home/nodejs/$version/bin/node"
+            ;;
+          "runtime set node")
+            version="''${4:?missing version}"
+            global_flag="''${5:?missing global flag}"
+            test "$global_flag" = "--global"
+            printf 'runtime set node %s\n' "$version" >> "''${TEST_LOG:?}"
+            mkdir -p "$effective_pnpm_home/bin"
+            : > "$effective_pnpm_home/bin/node"
+            chmod +x "$effective_pnpm_home/bin/node"
             ;;
           *)
             printf 'unexpected fake pnpm args: %s\n' "$*" >&2
@@ -333,19 +355,19 @@ stdenv.mkDerivation {
           export PNPM_ACTIVATE_PNPM_BIN="$FAKE_PNPM"
           export TEST_PNPM_HOME TEST_LOG
           export PNPM_HOME="$TEST_PNPM_HOME"
-          export PATH="$TEST_PNPM_HOME/nodejs/20.11.1/bin:/usr/bin:$TEST_PNPM_HOME:/bin"
+          export PATH="$TEST_NODE_BIN:/usr/bin:$TEST_PNPM_HOME:/bin"
           EXPORTS="$($out/bin/pnpm-activate-env)"
           test -n "$EXPORTS"
           eval "$EXPORTS"
           case "$PATH" in
-            "$TEST_PNPM_HOME:"*) ;;
+            "$TEST_GLOBAL_BIN:"*) ;;
             *)
               echo "pnpm-activate-env did not prioritize PNPM_HOME on PATH" >&2
               exit 1
               ;;
           esac
           case ":$PATH:" in
-            *":$TEST_PNPM_HOME/nodejs/20.11.1/bin:") ;;
+            *":$TEST_NODE_BIN:") ;;
             *)
               echo "pnpm-activate-env did not add Node bin path to PATH" >&2
               exit 1
@@ -358,17 +380,17 @@ stdenv.mkDerivation {
           export PNPM_ACTIVATE_PNPM_BIN="$FAKE_PNPM"
           export TEST_PNPM_HOME TEST_LOG
           export PNPM_HOME="$TEST_PNPM_HOME"
-          export PATH="$TEST_PNPM_HOME/nodejs/20.11.1/bin:/usr/bin:$TEST_PNPM_HOME:/bin"
+          export PATH="$TEST_NODE_BIN:/usr/bin:$TEST_PNPM_HOME:/bin"
           . "$out/bin/pnpm-activate-env"
           case "$PATH" in
-            "$TEST_PNPM_HOME:$TEST_PNPM_HOME/nodejs/20.11.1/bin:"*) ;;
+            "$TEST_GLOBAL_BIN:"*) ;;
             *)
               echo "sourcing pnpm-activate-env did not prioritize PNPM_HOME before Node bin path" >&2
               exit 1
               ;;
           esac
           case ":$PATH:" in
-            *":$TEST_PNPM_HOME/nodejs/20.11.1/bin:") ;;
+            *":$TEST_NODE_BIN:") ;;
             *)
               echo "sourcing pnpm-activate-env did not add Node bin path to PATH" >&2
               exit 1
@@ -376,7 +398,37 @@ stdenv.mkDerivation {
           esac
         )
 
-        grep -q '^env add 20.11.1$' "$TEST_LOG"
+        grep -q "^$TEST_INSTALL_LOG$" "$TEST_LOG"
+
+        mkdir -p "$TEST_ROOT/runtime-package/packages/app"
+        cat > "$TEST_ROOT/runtime-package/package.json" <<'EOF'
+        {
+          "devEngines": {
+            "runtime": {
+              "name": "node",
+              "version": "^20.11.1",
+              "onFail": "download"
+            }
+          }
+        }
+        EOF
+
+        (
+          cd "$TEST_ROOT/runtime-package/packages/app"
+          export PNPM_ACTIVATE_PNPM_BIN="$FAKE_PNPM"
+          export TEST_PNPM_HOME TEST_LOG
+          export PNPM_HOME="$TEST_PNPM_HOME"
+          before_lines=$(wc -l < "$TEST_LOG" | tr -d '[:space:]')
+          EXPORTS="$($out/bin/pnpm-activate-env)"
+          if [ "$TEST_USE_RUNTIME" = "1" ]; then
+            test -n "$EXPORTS"
+            grep -q '^runtime set node \^20.11.1$' "$TEST_LOG"
+          else
+            test -z "$EXPORTS"
+            after_lines=$(wc -l < "$TEST_LOG" | tr -d '[:space:]')
+            test "$before_lines" -eq "$after_lines"
+          fi
+        )
 
         cat > "$TEST_ROOT/ws/pnpm-workspace.yaml" <<'EOF'
         useNodeVersion: lts

--- a/packages/pnpm/package.nix
+++ b/packages/pnpm/package.nix
@@ -2,11 +2,13 @@
 
 callPackage ./common.nix {
   pname = "pnpm";
-  version = "10.33.2";
+  version = "11.0.4";
+  description = "Fast, disk space efficient package manager (standalone, no Node.js dependency)";
+  exeHash = "sha256-Vkf+hpA6Tim8eDSaPhI0Wwn1kUsMH8AAAXH6IBnWYRg=";
   hashes = {
-    "x86_64-linux" = "sha256-wzjNGhmgz9tf/SK/vlBNpZXo0c6unyShRcR5kOaO+jo=";
-    "aarch64-linux" = "sha256-jRq0Q4ZqTTZkDsNnFfuQcY3TcctaWd6PD+izwtsnOiI=";
-    "x86_64-darwin" = "sha256-zTHC3LSgCx4LwG4rEloiUwFKIpiNfF87TTmZ3jbQm+A=";
-    "aarch64-darwin" = "sha256-iwVUZDSoFHxmXJ+X6zg4DAF1IiNP62jfBeC4UoxPCMw=";
+    "x86_64-linux" = "sha256-gdUd4nPY4KVwBxcN6S0V/qBjMT7RBYmYstXWFl/7aKQ=";
+    "aarch64-linux" = "sha256-KuOBPaUgoc+eHbFMxQD/EcpoZPnRMT39gHv1zfTzN8M=";
+    "x86_64-darwin" = "sha256-WZlaKunniQHKbIqwyA9B4ddYodeyodODZGFSqf3f55o=";
+    "aarch64-darwin" = "sha256-tNbvgDQsCbs8D3y5+EE1Adp4wKZiP94AYTXTLBbt9OQ=";
   };
 }

--- a/packages/pnpm/pnpm-activate-env.sh
+++ b/packages/pnpm/pnpm-activate-env.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+PNPM_ACTIVATE_USE_RUNTIME="@PNPM_ACTIVATE_USE_RUNTIME@"
+
 usage() {
 	cat <<'EOF'
 Usage: pnpm-activate-env [--print-export] [--workspace-file <path>]
@@ -57,6 +59,23 @@ find_workspace_file() {
 	done
 }
 
+find_package_json() {
+	local search_dir="$PWD"
+
+	while :; do
+		if [ -f "${search_dir}/package.json" ]; then
+			printf '%s\n' "${search_dir}/package.json"
+			return 0
+		fi
+
+		if [ "$search_dir" = "/" ]; then
+			return 1
+		fi
+
+		search_dir="$(dirname "$search_dir")"
+	done
+}
+
 extract_use_node_version() {
 	local workspace_file="$1"
 	local line raw value
@@ -94,10 +113,50 @@ extract_use_node_version() {
 	return 1
 }
 
+extract_dev_engines_node_version() {
+	local package_json="$1"
+	local compact
+	local runtime
+	local version
+
+	compact="$(tr -d '\n\r' <"$package_json")"
+
+	case "$compact" in
+	*'"devEngines"'*'"runtime"'*) ;;
+	*) return 1 ;;
+	esac
+
+	runtime="$(printf '%s\n' "$compact" | sed -n 's/.*"runtime"[[:space:]]*:[[:space:]]*\(\[[^]]*\]\|{[^}]*}\).*/\1/p')"
+	if [ -z "$runtime" ]; then
+		return 1
+	fi
+
+	version="$(printf '%s\n' "$runtime" | sed -n 's/.*"name"[[:space:]]*:[[:space:]]*"node".*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
+	if [ -z "$version" ]; then
+		version="$(printf '%s\n' "$runtime" | sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*"name"[[:space:]]*:[[:space:]]*"node".*/\1/p')"
+	fi
+
+	if [ -n "$version" ]; then
+		printf '%s\n' "$version"
+		return 0
+	fi
+
+	return 1
+}
+
 is_valid_node_version() {
 	local value="$1"
 
 	[[ "$value" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z]+([.-][0-9A-Za-z]+)*)?(\+[0-9A-Za-z.-]+)?$ ]]
+}
+
+is_valid_runtime_version() {
+	local value="$1"
+
+	case "$value" in
+	"" | *[!A-Za-z0-9._+/'<''>''='~'^'*-]*) return 1 ;;
+	*) return 0 ;;
+	esac
 }
 
 normalize_version() {
@@ -197,13 +256,21 @@ resolve_pnpm_home() {
 emit_export_script() {
 	local pnpm_home="$1"
 	local node_bin="$2"
+	local global_bin="$pnpm_home"
 	local quoted_pnpm_home
+	local quoted_global_bin
 	local quoted_node_bin
 
+	if [ "$PNPM_ACTIVATE_USE_RUNTIME" = "1" ]; then
+		global_bin="${pnpm_home}/bin"
+	fi
+
 	quoted_pnpm_home="$(shell_quote "$pnpm_home")"
+	quoted_global_bin="$(shell_quote "$global_bin")"
 	quoted_node_bin="$(shell_quote "$node_bin")"
 
 	printf '__pnpm_activate_pnpm_home=%s\n' "$quoted_pnpm_home"
+	printf '__pnpm_activate_global_bin=%s\n' "$quoted_global_bin"
 	printf '__pnpm_activate_node_bin=%s\n' "$quoted_node_bin"
 	cat <<'EOF'
 export PNPM_HOME="${__pnpm_activate_pnpm_home}"
@@ -211,7 +278,7 @@ __pnpm_activate_old_path="${PATH:-}"
 PATH=""
 IFS=:
 for __pnpm_activate_path_entry in ${__pnpm_activate_old_path}; do
-  if [ "${__pnpm_activate_path_entry}" != "${__pnpm_activate_pnpm_home}" ] && [ "${__pnpm_activate_path_entry}" != "${__pnpm_activate_node_bin}" ]; then
+  if [ "${__pnpm_activate_path_entry}" != "${__pnpm_activate_global_bin}" ] && [ "${__pnpm_activate_path_entry}" != "${__pnpm_activate_node_bin}" ]; then
     if [ -z "${PATH}" ]; then
       PATH="${__pnpm_activate_path_entry}"
     else
@@ -220,24 +287,32 @@ for __pnpm_activate_path_entry in ${__pnpm_activate_old_path}; do
   fi
 done
 unset IFS
-export PATH="${__pnpm_activate_pnpm_home}:${__pnpm_activate_node_bin}:${PATH}"
-unset __pnpm_activate_pnpm_home __pnpm_activate_node_bin __pnpm_activate_old_path __pnpm_activate_path_entry
+if [ "${__pnpm_activate_global_bin}" = "${__pnpm_activate_node_bin}" ]; then
+  export PATH="${__pnpm_activate_global_bin}:${PATH}"
+else
+  export PATH="${__pnpm_activate_global_bin}:${__pnpm_activate_node_bin}:${PATH}"
+fi
+unset __pnpm_activate_pnpm_home __pnpm_activate_global_bin __pnpm_activate_node_bin __pnpm_activate_old_path __pnpm_activate_path_entry
 EOF
 }
 
 apply_path() {
 	local pnpm_home="$1"
 	local node_bin="$2"
-
+	local global_bin="$pnpm_home"
 	local old_path="$PATH"
 	local new_path=""
 	local entry
+
+	if [ "$PNPM_ACTIVATE_USE_RUNTIME" = "1" ]; then
+		global_bin="${pnpm_home}/bin"
+	fi
 
 	export PNPM_HOME="$pnpm_home"
 
 	IFS=:
 	for entry in $old_path; do
-		if [ "$entry" != "$pnpm_home" ] && [ "$entry" != "$node_bin" ]; then
+		if [ "$entry" != "$global_bin" ] && [ "$entry" != "$node_bin" ]; then
 			if [ -z "$new_path" ]; then
 				new_path="$entry"
 			else
@@ -247,7 +322,11 @@ apply_path() {
 	done
 	unset IFS
 
-	export PATH="${pnpm_home}:${node_bin}:${new_path}"
+	if [ "$global_bin" = "$node_bin" ]; then
+		export PATH="${global_bin}:${new_path}"
+	else
+		export PATH="${global_bin}:${node_bin}:${new_path}"
+	fi
 }
 
 main() {
@@ -284,19 +363,34 @@ main() {
 		workspace_file="$(find_workspace_file || true)"
 	fi
 
-	if [ -z "$workspace_file" ] || [ ! -f "$workspace_file" ]; then
-		return 0
+	local requested_version=""
+	local requested_source=""
+
+	if [ -n "$workspace_file" ] && [ -f "$workspace_file" ]; then
+		requested_version="$(extract_use_node_version "$workspace_file" || true)"
+		requested_source="$workspace_file"
 	fi
 
-	local requested_version=""
-	requested_version="$(extract_use_node_version "$workspace_file" || true)"
+	if [ -z "$requested_version" ] && [ "$PNPM_ACTIVATE_USE_RUNTIME" = "1" ]; then
+		local package_json=""
+		package_json="$(find_package_json || true)"
+		if [ -n "$package_json" ] && [ -f "$package_json" ]; then
+			requested_version="$(extract_dev_engines_node_version "$package_json" || true)"
+			requested_source="$package_json"
+		fi
+	fi
 
 	if [ -z "$requested_version" ]; then
 		return 0
 	fi
 
-	if ! is_valid_node_version "$requested_version"; then
-		echo "pnpm-activate-env: ignoring unsupported useNodeVersion '${requested_version}' in ${workspace_file}" >&2
+	if [ "$PNPM_ACTIVATE_USE_RUNTIME" = "1" ]; then
+		if ! is_valid_runtime_version "$requested_version"; then
+			echo "pnpm-activate-env: ignoring unsupported Node.js runtime '${requested_version}' in ${requested_source}" >&2
+			return 0
+		fi
+	elif ! is_valid_node_version "$requested_version"; then
+		echo "pnpm-activate-env: ignoring unsupported useNodeVersion '${requested_version}' in ${requested_source}" >&2
 		return 0
 	fi
 
@@ -315,13 +409,20 @@ main() {
 		run_path="${pnpm_home}:${run_path}"
 	fi
 
-	node_bin="${pnpm_home}/nodejs/${version}/bin"
-	if [ ! -x "${node_bin}/node" ]; then
-		PNPM_HOME="$pnpm_home" PATH="$run_path" "$pnpm_bin" env add --global "$version" >&2
+	if [ "$PNPM_ACTIVATE_USE_RUNTIME" = "1" ]; then
+		node_bin="${pnpm_home}/bin"
+		if [ ! -x "${node_bin}/node" ]; then
+			PNPM_HOME="$pnpm_home" PATH="${pnpm_home}/bin:$run_path" "$pnpm_bin" runtime set node "$version" --global >&2
+		fi
+	else
+		node_bin="${pnpm_home}/nodejs/${version}/bin"
+		if [ ! -x "${node_bin}/node" ]; then
+			PNPM_HOME="$pnpm_home" PATH="$run_path" "$pnpm_bin" env add --global "$version" >&2
+		fi
 	fi
 
 	if [ ! -x "${node_bin}/node" ]; then
-		echo "pnpm-activate-env: expected node binary at ${node_bin}/node after pnpm env add" >&2
+		echo "pnpm-activate-env: expected node binary at ${node_bin}/node after installing Node.js ${version}" >&2
 		return 1
 	fi
 

--- a/scripts/update
+++ b/scripts/update
@@ -743,13 +743,48 @@ def npm-dist-tag [pkg: string, tag: string] {
 def update-pnpm [packages_dir: string, dry_run: bool] {
   let latest_version = (npm-dist-tag "pnpm" "latest")
   let file = $"($packages_dir)/pnpm/package.nix"
-  let entries = [
+  let content = (open $file --raw)
+  let current_version = (parse-capture $content 'version = "([^"]+)"')
+  if ($current_version | is-empty) {
+    fail "could not parse version for pnpm"
+  }
+
+  if $current_version == $latest_version {
+    log-ok "pnpm" $"up to date \(v($current_version)\)"
+    return false
+  }
+
+  log-update "pnpm" $"v($current_version) → v($latest_version)"
+  if $dry_run {
+    return true
+  }
+
+  mut updated = (replace-version $content $latest_version)
+
+  let platform_entries = [
     { key: "x86_64-linux", url: $"https://registry.npmjs.org/@pnpm/linux-x64/-/linux-x64-($latest_version).tgz" }
     { key: "aarch64-linux", url: $"https://registry.npmjs.org/@pnpm/linux-arm64/-/linux-arm64-($latest_version).tgz" }
     { key: "x86_64-darwin", url: $"https://registry.npmjs.org/@pnpm/macos-x64/-/macos-x64-($latest_version).tgz" }
     { key: "aarch64-darwin", url: $"https://registry.npmjs.org/@pnpm/macos-arm64/-/macos-arm64-($latest_version).tgz" }
   ]
-  update-versioned-keyed-hashes "pnpm" $file $latest_version $entries $dry_run
+  for entry in $platform_entries {
+    log-sub $"fetching ($entry.key)..."
+    let new_hash = (prefetch-sri $entry.url)
+    $updated = (replace-key-hash $updated $entry.key $new_hash)
+  }
+
+  # Update exeHash if present (v11+)
+  let current_exe_hash = (parse-capture $updated 'exeHash = "([^"]+)"')
+  if not ($current_exe_hash | is-empty) {
+    log-sub "fetching exe..."
+    let exe_url = $"https://registry.npmjs.org/@pnpm/exe/-/exe-($latest_version).tgz"
+    let exe_hash = (prefetch-sri $exe_url)
+    $updated = ($updated | str replace $"exeHash = \"($current_exe_hash)\"" $"exeHash = \"($exe_hash)\"")
+  }
+
+  $updated | save -f $file
+  log-ok "pnpm" "updated"
+  true
 }
 
 def update-pnpm-10 [packages_dir: string, dry_run: bool] {
@@ -765,7 +800,7 @@ def update-pnpm-10 [packages_dir: string, dry_run: bool] {
 }
 
 def update-pnpm-11 [packages_dir: string, dry_run: bool] {
-  let latest_version = (npm-dist-tag "pnpm" "next-11")
+  let latest_version = (npm-dist-tag "pnpm" "latest-11")
   let file = $"($packages_dir)/pnpm-11/package.nix"
   let content = (open $file --raw)
   let current_version = (parse-capture $content 'version = "([^"]+)"')
@@ -797,6 +832,7 @@ def update-pnpm-11 [packages_dir: string, dry_run: bool] {
     $updated = (replace-key-hash $updated $entry.key $new_hash)
   }
 
+  # Update exeHash
   log-sub "fetching exe..."
   let exe_url = $"https://registry.npmjs.org/@pnpm/exe/-/exe-($latest_version).tgz"
   let exe_hash = (prefetch-sri $exe_url)


### PR DESCRIPTION
## Summary

Adds pnpm v11 environment activation support, enabling the new `pnpm runtime` command and `devEngines.runtime` configuration from `package.json`.

### Key changes

- **`common.nix`**: Added `useRuntimeCommand` flag (`lib.versionAtLeast version "11"`) that gates v11-specific behavior
- **`pnpm-activate-env.sh`**: Full dual-mode support:
  - v10: reads `useNodeVersion` from `pnpm-workspace.yaml`, uses `pnpm env add`, global bin = `/Users/ifiokjr/Library/pnpm`
  - v11: also reads `devEngines.runtime` from `package.json`, uses `pnpm runtime set node`, global bin = `/Users/ifiokjr/Library/pnpm/bin`
  - `is_valid_runtime_version` allows semver ranges like `^20.11.1` (v11 `devEngines.runtime` spec)
- **`pnpm/package.nix`**: Upgraded to v11.0.4 with `exeHash` for auxiliary binaries (`pn`, `pnpx`, `pnx`)
- **`pnpm-11/package.nix`**: Updated description (v11 is stable, not pre-release)
- **`scripts/update`**: `update-pnpm` now conditionally updates `exeHash` (v11+); `update-pnpm-11` restored

### Package matrix

| Package | Version | Runtime mode | `pnpm env add` vs `pnpm runtime set` |
|---------|---------|-------------|---------------------------------------|
| `pnpm` | 11.0.4 | Runtime (`PNPM_HOME/bin`) | `pnpm runtime set node --global` |
| `pnpm-11` | 11.0.4 | Runtime (`PNPM_HOME/bin`) | `pnpm runtime set node --global` |
| `pnpm-10` | 10.33.2 | Legacy (`PNPM_HOME`) | `pnpm env add --global` |

### Tested

- All three packages build successfully on aarch64-darwin
- `pnpm-activate-env` correctly substitutes `PNPM_ACTIVATE_USE_RUNTIME` for each version
- Install check tests pass for both runtime modes
- Update script parses and runs correctly