### PR TITLE
feat(herdr): add herdr agent multiplexer CLI v0.5.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ jobs:
       - name: 🔍 detect changed packages
         id: changes
         run: |
-          LINUX_PACKAGES="agave agave-2_0 agave-2_1 agave-2_2 agave-2_3 agave-3_0 agave-3_1 cargo-interactive-update codex-cli deno dylint godot knope mdt monochange ollama pina pnpm pnpm-10 pnpm-11 pnpm-standalone racket-minimal secretspec surfpool wait-for-them"
-          MACOS_PACKAGES="agave agave-2_0 agave-2_1 agave-2_2 agave-2_3 agave-3_0 agave-3_1 cargo-interactive-update codex-cli deno dylint godot gpg-suite knope mdt monochange nordvpn ollama pina pnpm pnpm-10 pnpm-11 pnpm-standalone racket-minimal secretspec steam surfpool zoom"
+          LINUX_PACKAGES="agave agave-2_0 agave-2_1 agave-2_2 agave-2_3 agave-3_0 agave-3_1 cargo-interactive-update codex-cli deno dylint godot herdr knope mdt monochange ollama pina pnpm pnpm-10 pnpm-11 pnpm-standalone racket-minimal secretspec surfpool wait-for-them"
+          MACOS_PACKAGES="agave agave-2_0 agave-2_1 agave-2_2 agave-2_3 agave-3_0 agave-3_1 cargo-interactive-update codex-cli deno dylint godot gpg-suite herdr knope mdt monochange nordvpn ollama pina pnpm pnpm-10 pnpm-11 pnpm-standalone racket-minimal secretspec steam surfpool zoom"
 
           build_all=false
 

--- a/flake.nix
+++ b/flake.nix
@@ -29,6 +29,7 @@
         deno = final.callPackage ./packages/deno/package.nix { };
         godot = final.callPackage ./packages/godot/package.nix { };
         gpg-suite = final.callPackage ./packages/gpg-suite/package.nix { };
+        herdr = final.callPackage ./packages/herdr/package.nix { };
         ironclaw = final.callPackage ./packages/ironclaw/package.nix { };
         kani = final.callPackage ./packages/kani/package.nix { };
         knope = final.callPackage ./packages/knope/package.nix { };
@@ -77,6 +78,7 @@
           deno = pkgs.callPackage ./packages/deno/package.nix { };
           godot = pkgs.callPackage ./packages/godot/package.nix { };
           gpg-suite = pkgs.callPackage ./packages/gpg-suite/package.nix { };
+          herdr = pkgs.callPackage ./packages/herdr/package.nix { };
           ironclaw = pkgs.callPackage ./packages/ironclaw/package.nix { };
           kani = pkgs.callPackage ./packages/kani/package.nix { };
           knope = pkgs.callPackage ./packages/knope/package.nix { };

--- a/packages/herdr/package.nix
+++ b/packages/herdr/package.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+}:
+
+let
+  version = "0.5.10";
+
+  platformSuffix =
+    {
+      "aarch64-darwin" = "macos-aarch64";
+      "x86_64-darwin" = "macos-x86_64";
+      "aarch64-linux" = "linux-aarch64";
+      "x86_64-linux" = "linux-x86_64";
+    }
+    .${stdenv.hostPlatform.system} or (throw "Unsupported platform: ${stdenv.hostPlatform.system}");
+
+  hashes = {
+    "macos-aarch64" = "sha256-hKp/OMg1tOtao4wpZggTAjzyMXjkZUHEucJgcS/lLVE=";
+    "macos-x86_64" = "sha256-5yMqu9BWiHuv4Pa4Hlj1njPK/XrGCeO8w1S44A77Bjc=";
+    "linux-aarch64" = "sha256-ly1ips1U0BYtLegNuY2uQVt3L1WCL09fb4wy0BZLKbk=";
+    "linux-x86_64" = "sha256-9FwU+UnYW0dOcpd6AJ2B2lL7pORuKgJEjb+lk3Bl/Uw=";
+  };
+in
+stdenv.mkDerivation {
+  pname = "herdr";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://github.com/ogulcancelik/herdr/releases/download/v${version}/herdr-${platformSuffix}";
+    hash = hashes.${platformSuffix} or lib.fakeHash;
+  };
+
+  dontUnpack = true;
+  dontBuild = true;
+  dontStrip = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp $src $out/bin/herdr
+    chmod +x $out/bin/herdr
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Terminal agent multiplexer – tmux for coding agents";
+    homepage = "https://github.com/ogulcancelik/herdr";
+    license = lib.licenses.agpl3Only;
+    mainProgram = "herdr";
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+    tags = [
+      "cli"
+      "dev-tool"
+    ];
+  };
+}

--- a/scripts/update
+++ b/scripts/update
@@ -1134,6 +1134,19 @@ def update-rust-knope [repo_root: string, packages_dir: string, dry_run: bool] {
   update-rust-package $repo_root $packages_dir "knope" $latest_version $rev "knope-dev" "knope" $dry_run
 }
 
+def update-herdr [packages_dir: string, dry_run: bool] {
+  let tag = (github-latest-tag "ogulcancelik" "herdr")
+  let latest_version = ($tag | str replace --regex '^v' '')
+  let file = $"($packages_dir)/herdr/package.nix"
+  let entries = [
+    { key: "macos-aarch64", url: $"https://github.com/ogulcancelik/herdr/releases/download/($tag)/herdr-macos-aarch64" }
+    { key: "macos-x86_64", url: $"https://github.com/ogulcancelik/herdr/releases/download/($tag)/herdr-macos-x86_64" }
+    { key: "linux-aarch64", url: $"https://github.com/ogulcancelik/herdr/releases/download/($tag)/herdr-linux-aarch64" }
+    { key: "linux-x86_64", url: $"https://github.com/ogulcancelik/herdr/releases/download/($tag)/herdr-linux-x86_64" }
+  ]
+  update-versioned-keyed-hashes "herdr" $file $latest_version $entries $dry_run
+}
+
 def update-ironclaw [packages_dir: string, dry_run: bool] {
   let tag = (github-latest-tag-with-prefix "nearai" "ironclaw" "ironclaw-v")
   let latest_version = ($tag | str replace --regex '^ironclaw-v' '')
@@ -1487,6 +1500,7 @@ def main [
     { name: "deno", run: {|| update-deno $packages_dir $dry_run } }
     { name: "dylint", run: {|| update-prebuilt-dylint $packages_dir $dry_run } }
     { name: "godot", run: {|| update-godot $packages_dir $dry_run } }
+    { name: "herdr", run: {|| update-herdr $packages_dir $dry_run } }
     { name: "gpg-suite", run: {|| update-gpg-suite $packages_dir $dry_run } }
     { name: "ironclaw", run: {|| update-ironclaw $packages_dir $dry_run } }
     { name: "kani", run: {|| update-kani $packages_dir $dry_run } }


### PR DESCRIPTION
## Summary

Add `herdr` — a terminal agent multiplexer (tmux for coding agents).

### Package details
- **Version**: 0.5.10
- **Source**: GitHub release binaries from `ogulcancelik/herdr`
- **Build method**: `fetchurl` + bare binary (no archive, no source build)
- **Platforms**: aarch64-darwin, x86_64-darwin, aarch64-linux, x86_64-linux

### Changes
- `packages/herdr/package.nix` — Nix package using `fetchurl` for prebuilt binaries
- `flake.nix` — Added `herdr` to overlay and per-system packages
- `scripts/update` — Added `update-herdr` function using `update-versioned-keyed-hashes`
- `.github/workflows/ci.yml` — Added herdr to LINUX_PACKAGES and MACOS_PACKAGES

### Verification
- ✅ Builds on `aarch64-darwin`
- ✅ `herdr --version` → 0.5.10
- ✅ Evaluates for all 4 platforms
- ✅ Update script parses correctly