### PR TITLE
feat(keyring): add keyring package

### DIFF
--- a/.github/workflows/build-rust-prebuilt.yml
+++ b/.github/workflows/build-rust-prebuilt.yml
@@ -13,6 +13,7 @@ on:
           - cargo-clean-all
           - cargo-interactive-update
           - sbpf-linker
+          - keyring
       version:
         description: "Version to build (without v prefix)"
         required: true
@@ -33,12 +34,19 @@ jobs:
       features: ${{ steps.config.outputs.features }}
       no-default-features: ${{ steps.config.outputs.no-default-features }}
       tag: ${{ steps.config.outputs.tag }}
+      matrix: ${{ steps.config.outputs.matrix }}
     steps:
       - name: Configure package
         id: config
         run: |
           VERSION="${{ inputs.version }}"
           echo "tag=prebuilt/${{ inputs.package }}/${VERSION}" >> "$GITHUB_OUTPUT"
+
+          if [ "${{ inputs.package }}" = "keyring" ]; then
+            echo 'matrix={"include":[{"target":"aarch64-apple-darwin","os":"macos-latest"},{"target":"x86_64-apple-darwin","os":"macos-latest"},{"target":"aarch64-unknown-linux-gnu","os":"ubuntu-24.04-arm"},{"target":"x86_64-unknown-linux-gnu","os":"ubuntu-latest"}]}' >> "$GITHUB_OUTPUT"
+          else
+            echo 'matrix={"include":[{"target":"aarch64-apple-darwin","os":"macos-latest"},{"target":"x86_64-apple-darwin","os":"macos-latest"},{"target":"x86_64-unknown-linux-gnu","os":"ubuntu-latest"}]}' >> "$GITHUB_OUTPUT"
+          fi
 
           case "${{ inputs.package }}" in
             dylint)
@@ -63,6 +71,10 @@ jobs:
               echo "features=upstream-gallery-22" >> "$GITHUB_OUTPUT"
               echo "no-default-features=true" >> "$GITHUB_OUTPUT"
               ;;
+            keyring)
+              echo "repo=open-source-cooperative/keyring-rs" >> "$GITHUB_OUTPUT"
+              echo "bin=keyring" >> "$GITHUB_OUTPUT"
+              ;;
           esac
 
   build:
@@ -70,14 +82,7 @@ jobs:
     needs: prepare
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - target: aarch64-apple-darwin
-            os: macos-latest
-          - target: x86_64-apple-darwin
-            os: macos-latest
-          - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
+      matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
     runs-on: ${{ matrix.os }}
     permissions:
       contents: write
@@ -112,6 +117,12 @@ jobs:
           elif [ "${{ runner.os }}" = "macOS" ]; then
             brew install curl pkg-config
           fi
+
+      - name: Install system dependencies (keyring)
+        if: inputs.package == 'keyring' && runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pkg-config libdbus-1-dev
 
       - name: Install LLVM (sbpf-linker)
         if: inputs.package == 'sbpf-linker'
@@ -234,9 +245,8 @@ jobs:
               HASH=$(nix hash to-sri --type sha256 $(nix-prefetch-url --unpack "${URL}" 2>/dev/null) 2>/dev/null)
               echo "${PLATFORM}: ${HASH}"
 
-              # Update the hash in package.nix
-              # Match the pattern: "platform" = "sha256-..."
-              sed -i "s|\"${PLATFORM}\" = \"sha256-[^\"]*\"|\"${PLATFORM}\" = \"${HASH}\"|" "${FILE}"
+              # Update the hash in package.nix.
+              python3 -c 'import pathlib, re, sys; path = pathlib.Path(sys.argv[1]); platform = sys.argv[2]; hash_value = sys.argv[3]; text = path.read_text(); text = re.sub(r"\"" + re.escape(platform) + r"\" = (?:\"sha256-[^\"]*\"|lib\.fakeHash)", "\"" + platform + "\" = \"" + hash_value + "\"", text); path.write_text(text)' "${FILE}" "${PLATFORM}" "${HASH}"
             fi
           done
 

--- a/.github/workflows/build-rust-prebuilt.yml
+++ b/.github/workflows/build-rust-prebuilt.yml
@@ -242,7 +242,7 @@ jobs:
             if echo "${ASSETS}" | grep -q "${ASSET_NAME}"; then
               URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/${ASSET_NAME}"
               echo "Computing hash for ${PLATFORM}..."
-              HASH=$(nix hash to-sri --type sha256 $(nix-prefetch-url --unpack "${URL}" 2>/dev/null) 2>/dev/null)
+              HASH=$(nix hash to-sri --type sha256 $(nix-prefetch-url "${URL}" 2>/dev/null) 2>/dev/null)
               echo "${PLATFORM}: ${HASH}"
 
               # Update the hash in package.nix.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ jobs:
       - name: 🔍 detect changed packages
         id: changes
         run: |
-          LINUX_PACKAGES="agave agave-2_0 agave-2_1 agave-2_2 agave-2_3 agave-3_0 agave-3_1 cargo-interactive-update codex-cli deno dylint godot herdr knope mdt monochange ollama pina pnpm pnpm-10 pnpm-11 pnpm-standalone racket-minimal secretspec surfpool wait-for-them"
-          MACOS_PACKAGES="agave agave-2_0 agave-2_1 agave-2_2 agave-2_3 agave-3_0 agave-3_1 cargo-interactive-update codex-cli deno dylint godot gpg-suite herdr knope mdt monochange nordvpn ollama pina pnpm pnpm-10 pnpm-11 pnpm-standalone racket-minimal secretspec steam surfpool zoom"
+          LINUX_PACKAGES="agave agave-2_0 agave-2_1 agave-2_2 agave-2_3 agave-3_0 agave-3_1 cargo-interactive-update codex-cli deno dylint godot herdr keyring knope mdt monochange ollama pina pnpm pnpm-10 pnpm-11 pnpm-standalone racket-minimal secretspec surfpool wait-for-them"
+          MACOS_PACKAGES="agave agave-2_0 agave-2_1 agave-2_2 agave-2_3 agave-3_0 agave-3_1 cargo-interactive-update codex-cli deno dylint godot gpg-suite herdr keyring knope mdt monochange nordvpn ollama pina pnpm pnpm-10 pnpm-11 pnpm-standalone racket-minimal secretspec steam surfpool zoom"
 
           build_all=false
 

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -1,0 +1,70 @@
+# packages
+
+This flake exposes packages through both `packages.${system}` and `overlays.default`.
+
+## catalog
+
+| Package                                                                                            | Platforms              | Notes                                                        |
+| -------------------------------------------------------------------------------------------------- | ---------------------- | ------------------------------------------------------------ |
+| `agave`, `agave-4_0`, `agave-3_1`, `agave-3_0`, `agave-2_3`, `agave-2_2`, `agave-2_1`, `agave-2_0` | linux x64, macOS       | Agave/Solana validator client and CLI tracks                 |
+| `cargo-clean-all`                                                                                  | linux, macOS           | Recursively clean Cargo project targets                      |
+| `cargo-interactive-update`                                                                         | linux, macOS           | Interactively update Cargo dependencies                      |
+| `codex-cli`                                                                                        | linux, macOS           | OpenAI Codex CLI                                             |
+| `deno`                                                                                             | linux, macOS           | Deno runtime from pre-built releases                         |
+| `dylint`                                                                                           | linux, macOS           | Rust lint tooling                                            |
+| `godot`                                                                                            | linux, macOS           | Godot editor/launcher from upstream binaries                 |
+| `gpg-suite`                                                                                        | macOS                  | GPG Suite app bundle                                         |
+| `herdr`                                                                                            | linux, macOS           | Terminal agent multiplexer                                   |
+| `ironclaw`                                                                                         | linux, macOS           | NEAR AI Agent OS                                             |
+| `kani`                                                                                             | linux, macOS           | Rust model checker                                           |
+| `keyring`                                                                                          | linux, macOS           | Rust Keyring CLI; repo-hosted prebuilts with source fallback |
+| `knope`                                                                                            | linux, macOS           | Release/changelog/version automation                         |
+| `mdt`                                                                                              | linux, macOS           | Markdown templating updater                                  |
+| `monochange`                                                                                       | linux, macOS           | Monorepo version and release manager                         |
+| `nordvpn`                                                                                          | macOS                  | NordVPN client                                               |
+| `ollama`                                                                                           | linux, macOS           | Local LLM CLI/app                                            |
+| `op`                                                                                               | linux, macOS           | 1Password CLI beta channel                                   |
+| `pina`                                                                                             | linux, macOS           | Solana smart contract framework CLI                          |
+| `pnpm`, `pnpm-11`, `pnpm-10`, `pnpm-standalone`                                                    | linux, macOS           | Standalone pnpm tracks and compatibility alias               |
+| `racket-minimal`                                                                                   | linux, macOS           | Minimal Racket distribution                                  |
+| `sbpf-linker`                                                                                      | macOS                  | SBPF linker                                                  |
+| `secretspec`                                                                                       | linux, macOS           | Declarative secrets CLI                                      |
+| `solana-verify`                                                                                    | linux x64, macOS arm64 | Verifiable Solana builds                                     |
+| `steam`                                                                                            | macOS                  | Steam app bundle                                             |
+| `surfpool`                                                                                         | linux x64, macOS       | Solana test-validator replacement                            |
+| `wait-for-them`                                                                                    | linux x64, macOS x64   | TCP/HTTP readiness helper                                    |
+| `zoom`                                                                                             | macOS                  | Zoom client                                                  |
+
+## usage
+
+Run a package directly:
+
+```bash
+nix run github:ifiokjr/nixpkgs#secretspec -- --version
+nix run github:ifiokjr/nixpkgs#herdr -- --version
+nix run github:ifiokjr/nixpkgs#pnpm -- --version
+```
+
+Use from another flake:
+
+```nix
+let
+  extra = inputs.ifiokjr-nixpkgs.packages.${system};
+in {
+  environment.systemPackages = [
+    extra.herdr
+    extra.ironclaw
+    extra.keyring
+    extra.op
+    extra.pnpm
+    extra.secretspec
+  ];
+}
+```
+
+## pnpm tracks
+
+- `pnpm` tracks the latest standalone pnpm release.
+- `pnpm-11` tracks the latest v11 release and uses `pnpm runtime set node` in `pnpm-activate-env`.
+- `pnpm-10` tracks the latest v10 release and uses `pnpm env add --global` in `pnpm-activate-env`.
+- `pnpm-standalone` is a compatibility alias for `pnpm`.

--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,7 @@
         herdr = final.callPackage ./packages/herdr/package.nix { };
         ironclaw = final.callPackage ./packages/ironclaw/package.nix { };
         kani = final.callPackage ./packages/kani/package.nix { };
+        keyring = final.callPackage ./packages/keyring/package.nix { };
         knope = final.callPackage ./packages/knope/package.nix { };
         mdt = final.callPackage ./packages/mdt/package.nix { };
         monochange = final.callPackage ./packages/monochange/package.nix { };
@@ -81,6 +82,7 @@
           herdr = pkgs.callPackage ./packages/herdr/package.nix { };
           ironclaw = pkgs.callPackage ./packages/ironclaw/package.nix { };
           kani = pkgs.callPackage ./packages/kani/package.nix { };
+          keyring = pkgs.callPackage ./packages/keyring/package.nix { };
           knope = pkgs.callPackage ./packages/knope/package.nix { };
           mdt = pkgs.callPackage ./packages/mdt/package.nix { };
           monochange = pkgs.callPackage ./packages/monochange/package.nix { };

--- a/mdt.toml
+++ b/mdt.toml
@@ -15,6 +15,7 @@ v = { command = "./scripts/versions", format = "json", watch = [
 	"packages/godot/package.nix",
 	"packages/gpg-suite/package.nix",
 	"packages/kani/package.nix",
+	"packages/keyring/package.nix",
 	"packages/knope/package.nix",
 	"packages/mdt/package.nix",
 	"packages/monochange/package.nix",

--- a/packages/keyring/package.nix
+++ b/packages/keyring/package.nix
@@ -66,7 +66,10 @@ let
     cargoHash = "sha256-ePXiHOs+EhgoP6e6TSm56FxrKVq4zbkZaTmfXUnew8E=";
 
     nativeBuildInputs = [ pkg-config ];
-    buildInputs = lib.optionals stdenv.isLinux [ dbus ];
+    buildInputs = lib.optionals stdenv.isLinux [
+      dbus
+      stdenv.cc.cc.lib
+    ];
 
     cargoBuildFlags = [
       "--bin"
@@ -98,7 +101,10 @@ let
     dontStrip = true;
 
     nativeBuildInputs = lib.optionals stdenv.isLinux [ autoPatchelfHook ];
-    buildInputs = lib.optionals stdenv.isLinux [ dbus ];
+    buildInputs = lib.optionals stdenv.isLinux [
+      dbus
+      stdenv.cc.cc.lib
+    ];
 
     installPhase = ''
       runHook preInstall

--- a/packages/keyring/package.nix
+++ b/packages/keyring/package.nix
@@ -22,10 +22,10 @@ let
     .${stdenv.hostPlatform.system} or (throw "Unsupported platform: ${stdenv.hostPlatform.system}");
 
   hashes = {
-    "aarch64-apple-darwin" = lib.fakeHash;
-    "x86_64-apple-darwin" = lib.fakeHash;
-    "aarch64-unknown-linux-gnu" = lib.fakeHash;
-    "x86_64-unknown-linux-gnu" = lib.fakeHash;
+    "aarch64-apple-darwin" = "sha256-f+9ip7gObvrSn476S2Xw75s0YhlLF9LrnRbHswZsmUo=";
+    "x86_64-apple-darwin" = "sha256-WhLGDLoUAiIp9u/vlSmZCfh8LKwBx8SlN8k7j2OrdwI=";
+    "aarch64-unknown-linux-gnu" = "sha256-9CYuLtpEKm0Aes8BAC9oOBXuCxuXOhjaD1iWLXHK6aE=";
+    "x86_64-unknown-linux-gnu" = "sha256-+hdK7l3TMqWCpA2MPaUCy4OfYgEBMFp401lFT1QJ/O8=";
   };
 
   prebuiltHash = hashes.${platformSuffix} or lib.fakeHash;

--- a/packages/keyring/package.nix
+++ b/packages/keyring/package.nix
@@ -22,10 +22,10 @@ let
     .${stdenv.hostPlatform.system} or (throw "Unsupported platform: ${stdenv.hostPlatform.system}");
 
   hashes = {
-    "aarch64-apple-darwin" = "sha256-f+9ip7gObvrSn476S2Xw75s0YhlLF9LrnRbHswZsmUo=";
-    "x86_64-apple-darwin" = "sha256-WhLGDLoUAiIp9u/vlSmZCfh8LKwBx8SlN8k7j2OrdwI=";
-    "aarch64-unknown-linux-gnu" = "sha256-9CYuLtpEKm0Aes8BAC9oOBXuCxuXOhjaD1iWLXHK6aE=";
-    "x86_64-unknown-linux-gnu" = "sha256-+hdK7l3TMqWCpA2MPaUCy4OfYgEBMFp401lFT1QJ/O8=";
+    "aarch64-apple-darwin" = "sha256-xiMJsFI8WqpjBBYtSR2oQnn5bpKFxhq7eFEoSwcBTwk=";
+    "x86_64-apple-darwin" = "sha256-Nbd+jwnJNolIkeAaMNKTbbkeZaJ6X6Hek9rn/w4qzj0=";
+    "aarch64-unknown-linux-gnu" = "sha256-SHm9GRdQFLQHCvIg7f0varCsbpUS7aU6Z5hxPl7dkX4=";
+    "x86_64-unknown-linux-gnu" = "sha256-C76Dn4ASog41Ceszqm//OsKzJyb///YrLmPXiTxE4no=";
   };
 
   prebuiltHash = hashes.${platformSuffix} or lib.fakeHash;

--- a/packages/keyring/package.nix
+++ b/packages/keyring/package.nix
@@ -1,0 +1,123 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  fetchFromGitHub,
+  rustPlatform,
+  pkg-config,
+  autoPatchelfHook,
+  dbus,
+}:
+
+let
+  version = "4.0.1";
+
+  platformSuffix =
+    {
+      "aarch64-darwin" = "aarch64-apple-darwin";
+      "x86_64-darwin" = "x86_64-apple-darwin";
+      "aarch64-linux" = "aarch64-unknown-linux-gnu";
+      "x86_64-linux" = "x86_64-unknown-linux-gnu";
+    }
+    .${stdenv.hostPlatform.system} or (throw "Unsupported platform: ${stdenv.hostPlatform.system}");
+
+  hashes = {
+    "aarch64-apple-darwin" = lib.fakeHash;
+    "x86_64-apple-darwin" = lib.fakeHash;
+    "aarch64-unknown-linux-gnu" = lib.fakeHash;
+    "x86_64-unknown-linux-gnu" = lib.fakeHash;
+  };
+
+  prebuiltHash = hashes.${platformSuffix} or lib.fakeHash;
+  hasPrebuilt = prebuiltHash != lib.fakeHash;
+
+  meta = {
+    description = "Sample code and CLI for the Rust Keyring";
+    homepage = "https://github.com/open-source-cooperative/keyring-rs/wiki/Keyring";
+    license = with lib.licenses; [
+      asl20
+      mit
+    ];
+    mainProgram = "keyring";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+    tags = [
+      "cli"
+      "secrets"
+      "rust"
+    ];
+  };
+
+  sourceBuild = rustPlatform.buildRustPackage {
+    pname = "keyring";
+    inherit version;
+
+    src = fetchFromGitHub {
+      owner = "open-source-cooperative";
+      repo = "keyring-rs";
+      rev = "v${version}";
+      hash = "sha256-H074FaMgRRdqRfkM8QCIN0/DifFKSSoWo1H76b0EL+w=";
+    };
+
+    cargoHash = "sha256-ePXiHOs+EhgoP6e6TSm56FxrKVq4zbkZaTmfXUnew8E=";
+
+    nativeBuildInputs = [ pkg-config ];
+    buildInputs = lib.optionals stdenv.isLinux [ dbus ];
+
+    cargoBuildFlags = [
+      "--bin"
+      "keyring"
+    ];
+
+    doCheck = false;
+    doInstallCheck = true;
+    installCheckPhase = ''
+      $out/bin/keyring --help > /dev/null
+    '';
+
+    meta = meta // {
+      sourceProvenance = [ lib.sourceTypes.fromSource ];
+    };
+  };
+
+  prebuilt = stdenv.mkDerivation {
+    pname = "keyring";
+    inherit version;
+
+    src = fetchurl {
+      url = "https://github.com/ifiokjr/nixpkgs/releases/download/prebuilt/keyring/${version}/keyring-${platformSuffix}.tar.gz";
+      hash = prebuiltHash;
+    };
+
+    dontUnpack = true;
+    dontBuild = true;
+    dontStrip = true;
+
+    nativeBuildInputs = lib.optionals stdenv.isLinux [ autoPatchelfHook ];
+    buildInputs = lib.optionals stdenv.isLinux [ dbus ];
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/bin
+      tar xzf $src -C $out/bin/
+      chmod +x $out/bin/keyring
+
+      runHook postInstall
+    '';
+
+    doInstallCheck = true;
+    installCheckPhase = ''
+      $out/bin/keyring --help > /dev/null
+    '';
+
+    meta = meta // {
+      sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    };
+  };
+in
+if hasPrebuilt then prebuilt else sourceBuild

--- a/packages/secretspec/package.nix
+++ b/packages/secretspec/package.nix
@@ -19,7 +19,7 @@ rustPlatform.buildRustPackage {
     owner = "ifiokjr";
     repo = "secretspec";
     rev = "feat/provider-secret-locations";
-    hash = "sha256-J8Lmz4QCTUaEI35T7fIaydpM99mec6ZZwkkJEwFyjNQ=";
+    hash = "sha256-kK2JISUVGV4xREX9lPS0H1c6qEx9UpzH5gts9HP4QRY=";
   };
 
   cargoHash = "sha256-rzWzjAkK0keqFnt3TsXKTrFc0yIWQXiGBy2zIG+k4H4=";

--- a/packages/secretspec/package.nix
+++ b/packages/secretspec/package.nix
@@ -18,8 +18,8 @@ rustPlatform.buildRustPackage {
   src = fetchFromGitHub {
     owner = "ifiokjr";
     repo = "secretspec";
-    rev = "feat/provider-secret-locations";
-    hash = "sha256-kK2JISUVGV4xREX9lPS0H1c6qEx9UpzH5gts9HP4QRY=";
+    rev = "25620b62168cb3d59282a97fbee2cc85cb2b8b0a";
+    hash = "sha256-zYsMaaRjJk55MhaN7N0znlIw8CVPfTnx9zNk/4jkC/Q=";
   };
 
   cargoHash = "sha256-rzWzjAkK0keqFnt3TsXKTrFc0yIWQXiGBy2zIG+k4H4=";

--- a/packages/secretspec/package.nix
+++ b/packages/secretspec/package.nix
@@ -18,8 +18,8 @@ rustPlatform.buildRustPackage {
   src = fetchFromGitHub {
     owner = "ifiokjr";
     repo = "secretspec";
-    rev = "25620b62168cb3d59282a97fbee2cc85cb2b8b0a";
-    hash = "sha256-zYsMaaRjJk55MhaN7N0znlIw8CVPfTnx9zNk/4jkC/Q=";
+    rev = "0848257f05e9e64892689afdf5f658812babd6f8";
+    hash = "sha256-17T8UUAGYTBgZnaYhONPicGNQKzfbgY/RzbEr3RqeLc=";
   };
 
   cargoHash = "sha256-rzWzjAkK0keqFnt3TsXKTrFc0yIWQXiGBy2zIG+k4H4=";

--- a/readme.md
+++ b/readme.md
@@ -23,16 +23,24 @@ Additional Nix packages not yet available in [nixpkgs](https://github.com/NixOS/
 | [dylint](#dylint)                                     | <!-- {~v_dylint:"{{ v.dylint }}"} -->5.0.0<!-- {/v_dylint} -->                                                       | linux, macos               | Dylint tools for running Rust lints and building Dylint libraries             |
 | [godot](#godot)                                       | <!-- {~v_godot:"{{ v.godot }}"} -->4.6.2-stable<!-- {/v_godot} -->                                                   | linux, macos               | Free and open-source 2D and 3D game engine                                    |
 | [gpg-suite](#gpg-suite)                               | <!-- {~v_gpg_suite:"{{ v.gpg_suite }}"} -->2023.3<!-- {/v_gpg_suite} -->                                             | macos                      | GPG Suite - encryption, signing, and key management                           |
+| [herdr](#herdr)                                       | <!-- {~v_herdr:"{{ v.herdr }}"} -->0.5.10<!-- {/v_herdr} -->                                                         | linux, macos               | Terminal agent multiplexer - tmux for coding agents                           |
+| [ironclaw](#ironclaw)                                 | <!-- {~v_ironclaw:"{{ v.ironclaw }}"} -->0.28.2<!-- {/v_ironclaw} -->                                                | linux, macos               | Agent OS focused on privacy, security, and extensibility (NEAR AI)            |
 | [kani](#kani)                                         | <!-- {~v_kani:"{{ v.kani }}"} -->0.67.0<!-- {/v_kani} -->                                                            | linux, macos               | Bit-precise model checker for Rust                                            |
+| [keyring](#keyring)                                   | <!-- {~v_keyring:"{{ v.keyring }}"} -->4.0.1<!-- {/v_keyring} -->                                                    | linux, macos               | Sample code and CLI for the Rust Keyring                                      |
 | [knope](#knope)                                       | <!-- {~v_knope:"{{ v.knope }}"} -->0.22.4<!-- {/v_knope} -->                                                         | linux, macos               | Automate common development tasks (changelogs, releases, versioning)          |
 | [mdt](#mdt)                                           | <!-- {~v_mdt:"{{ v.mdt }}"} -->0.7.0<!-- {/v_mdt} -->                                                                | linux, macos               | Update markdown content anywhere using comments as template tags              |
 | [monochange](#monochange)                             | <!-- {~v_monochange:"{{ v.monochange }}"} -->0.5.1<!-- {/v_monochange} -->                                           | linux, macos               | Manage versions and releases for your multiplatform monorepo                  |
 | [nordvpn](#nordvpn)                                   | <!-- {~v_nordvpn:"{{ v.nordvpn }}"} -->10.1.0<!-- {/v_nordvpn} -->                                                   | macos                      | NordVPN macOS client                                                          |
 | [ollama](#ollama)                                     | <!-- {~v_ollama:"{{ v.ollama }}"} -->0.23.0<!-- {/v_ollama} -->                                                      | linux, macos               | Run local LLMs with Ollama via CLI and desktop app                            |
+| [op](#op)                                             | <!-- {~v_op:"{{ v.op }}"} -->2.35.0-beta.01<!-- {/v_op} -->                                                          | linux, macos               | 1Password CLI beta channel with environment support                           |
 | [pina](#pina)                                         | <!-- {~v_pina:"{{ v.pina }}"} -->0.8.0<!-- {/v_pina} -->                                                             | linux, macos               | CLI for Pina, a performant Solana smart contract framework                    |
-| [pnpm-standalone](#pnpm-standalone)                   | <!-- {~v_pnpm_standalone:"{{ v.pnpm_standalone }}"} --><!-- {/v_pnpm_standalone} -->                                 | linux, macos               | Fast, disk-space efficient package manager (no Node.js dependency)            |
+| [pnpm](#pnpm)                                         | <!-- {~v_pnpm:"{{ v.pnpm }}"} -->11.0.4<!-- {/v_pnpm} -->                                                            | linux, macos               | Fast, disk-space efficient package manager (latest standalone track)          |
+| [pnpm-10](#pnpm)                                      | <!-- {~v_pnpm_10:"{{ v.pnpm_10 }}"} -->10.33.2<!-- {/v_pnpm_10} -->                                                  | linux, macos               | Standalone pnpm pinned to the latest v10 release track                        |
+| [pnpm-11](#pnpm)                                      | <!-- {~v_pnpm_11:"{{ v.pnpm_11 }}"} -->11.0.4<!-- {/v_pnpm_11} -->                                                   | linux, macos               | Standalone pnpm pinned to the latest v11 release track                        |
+| [pnpm-standalone](#pnpm)                              | <!-- {~v_pnpm_standalone:"{{ v.pnpm_standalone }}"} --><!-- {/v_pnpm_standalone} -->                                 | linux, macos               | Fast, disk-space efficient package manager (no Node.js dependency)            |
 | [racket-minimal](#racket-minimal)                     | <!-- {~v_racket_minimal:"{{ v.racket_minimal }}"} -->9.1<!-- {/v_racket_minimal} -->                                 | linux, macos               | Racket programming language (minimal distribution, pre-built)                 |
 | [sbpf-linker](#sbpf-linker)                           | <!-- {~v_sbpf_linker:"{{ v.sbpf_linker }}"} -->0.1.8<!-- {/v_sbpf_linker} -->                                        | macos                      | Upstream BPF linker for SBPF V0 programs                                      |
+| [secretspec](#secretspec)                             | <!-- {~v_secretspec:"{{ v.secretspec }}"} -->0.10.1<!-- {/v_secretspec} -->                                          | linux, macos               | Declarative secrets, every environment, any provider                          |
 | [solana-verify](#solana-verify)                       | <!-- {~v_solana_verify:"{{ v.solana_verify }}"} -->0.4.15<!-- {/v_solana_verify} -->                                 | linux (x64), macos (arm64) | CLI tool for building verifiable Solana programs                              |
 | [steam](#steam)                                       | <!-- {~v_steam:"{{ v.steam }}"} -->4.0<!-- {/v_steam} -->                                                            | macos                      | Steam video game digital distribution service                                 |
 | [surfpool](#surfpool)                                 | <!-- {~v_surfpool:"{{ v.surfpool }}"} -->1.2.0<!-- {/v_surfpool} -->                                                 | linux (x64), macos         | A drop-in replacement for solana-test-validator with mainnet state simulation |
@@ -52,6 +60,12 @@ nix run github:ifiokjr/nixpkgs#codex-cli
 nix run github:ifiokjr/nixpkgs#deno
 nix run github:ifiokjr/nixpkgs#godot
 nix run github:ifiokjr/nixpkgs#ollama
+nix run github:ifiokjr/nixpkgs#herdr
+nix run github:ifiokjr/nixpkgs#ironclaw
+nix run github:ifiokjr/nixpkgs#op
+nix run github:ifiokjr/nixpkgs#pnpm
+nix run github:ifiokjr/nixpkgs#secretspec
+nix run github:ifiokjr/nixpkgs#keyring -- --help
 ```
 
 ### add to your flake
@@ -78,6 +92,12 @@ nix run github:ifiokjr/nixpkgs#ollama
           extra.monochange
           extra.pnpm-standalone
           extra.codex-cli
+          extra.herdr
+          extra.ironclaw
+          extra.keyring
+          extra.op
+          extra.pnpm
+          extra.secretspec
         ];
       };
     };
@@ -111,6 +131,12 @@ The overlay adds all packages into your nixpkgs set so you can reference them as
           pkgs.mdt
           pkgs.monochange
           pkgs.pnpm-standalone
+          pkgs.herdr
+          pkgs.ironclaw
+          pkgs.keyring
+          pkgs.op
+          pkgs.pnpm
+          pkgs.secretspec
         ];
       };
     };
@@ -141,6 +167,12 @@ in
     extra.mdt
     extra.monochange
     extra.pnpm-standalone
+    extra.herdr
+    extra.ironclaw
+    extra.keyring
+    extra.op
+    extra.pnpm
+    extra.secretspec
   ];
 }
 ```
@@ -172,6 +204,12 @@ in
               extra.zoom
               extra.knope
               extra.codex-cli
+              extra.herdr
+              extra.ironclaw
+              extra.keyring
+              extra.op
+              extra.pnpm
+              extra.secretspec
             ];
           }
         ];
@@ -206,6 +244,12 @@ in
               extra.pnpm-standalone
               extra.codex-cli
               extra.racket-minimal
+              extra.herdr
+              extra.ironclaw
+              extra.keyring
+              extra.op
+              extra.pnpm
+              extra.secretspec
             ];
           }
         ];
@@ -297,6 +341,22 @@ GPG Suite for macOS providing encryption, signing, and key management. Includes 
 - **License:** GPL-3.0
 - **Source:** <https://gpgtools.org/>
 
+### herdr
+
+Terminal agent multiplexer for running and switching between coding agents in tmux sessions. Installs the upstream pre-built release binary.
+
+- **Binary:** `herdr`
+- **License:** AGPL-3.0-only
+- **Source:** <https://github.com/ogulcancelik/herdr>
+
+### ironclaw
+
+Agent OS focused on privacy, security, and extensibility for NEAR AI workflows. Installs pre-built release binaries.
+
+- **Binary:** `ironclaw`
+- **License:** Apache-2.0, MIT
+- **Source:** <https://github.com/nearai/ironclaw>
+
 ### kani
 
 Bit-precise model checker for Rust. Installs the official upstream release bundle and provides both `kani` and `cargo-kani` commands.
@@ -305,6 +365,15 @@ Bit-precise model checker for Rust. Installs the official upstream release bundl
 - **License:** Apache-2.0, MIT
 - **Source:** <https://github.com/model-checking/kani>
 - **Homepage:** <https://model-checking.github.io/kani/>
+
+### keyring
+
+Sample code and CLI for the Rust Keyring crate. Upstream does not publish release binaries, so this package is set up to consume pre-built artifacts produced by this repo's `build-rust-prebuilt.yml` workflow from the upstream `keyring-rs` source tag. Until a prebuilt release exists for a platform, it falls back to a pinned source build with `cargoHash`.
+
+- **Binary:** `keyring`
+- **License:** Apache-2.0, MIT
+- **Source:** <https://github.com/open-source-cooperative/keyring-rs>
+- **Homepage:** <https://github.com/open-source-cooperative/keyring-rs/wiki/Keyring>
 
 ### knope
 
@@ -348,6 +417,14 @@ Ollama for running local LLMs. On macOS this installs `Ollama.app` plus the bund
 - **Source:** <https://github.com/ollama/ollama>
 - **Homepage:** <https://ollama.com/>
 
+### op
+
+1Password CLI beta channel, packaged for access to beta-only `op environment` support. Installs the official upstream pre-built binary.
+
+- **Binary:** `op`
+- **License:** Proprietary
+- **Source:** <https://developer.1password.com/docs/cli/>
+
 ### pina
 
 CLI for Pina, a performant Solana smart contract framework. Built from source using `rustPlatform.buildRustPackage`.
@@ -357,12 +434,14 @@ CLI for Pina, a performant Solana smart contract framework. Built from source us
 - **Source:** <https://github.com/pina-rs/pina>
 - **Homepage:** <https://pina.rs>
 
-### pnpm-standalone
+### pnpm
 
-Standalone pnpm binary with no Node.js dependency. Downloaded directly from GitHub releases. Includes `pnpm-activate-env` to read `useNodeVersion` from `pnpm-workspace.yaml`, install that Node.js version with `pnpm env add --global`, and emit PATH export commands.
+Standalone pnpm binary with no Node.js dependency. Downloaded directly from GitHub releases. `pnpm` tracks the latest release, while `pnpm-11` and `pnpm-10` are explicit versioned tracks. `pnpm-standalone` is kept as a compatibility alias for the latest track. Includes `pnpm-activate-env` to read `useNodeVersion` from `pnpm-workspace.yaml`, install that Node.js version with the appropriate pnpm runtime/env command, and emit PATH export commands.
 
 - **Binary:** `pnpm`, `pnpm-activate-env`
+- **Packages:** `pnpm`, `pnpm-11`, `pnpm-10`, `pnpm-standalone`
 - **Activate workspace Node version:** `eval "$(pnpm-activate-env)"`
+- **Runtime support:** v11 uses `pnpm runtime set node`; v10 uses `pnpm env add --global`
 - **License:** MIT
 - **Source:** <https://github.com/pnpm/pnpm>
 - **Homepage:** <https://pnpm.io/>
@@ -439,6 +518,15 @@ Upstream BPF linker for SBPF V0 programs. Built from source using `rustPlatform.
 - **License:** MIT
 - **Source:** <https://github.com/blueshift-gg/sbpf-linker>
 
+### secretspec
+
+Declarative secrets tooling for every environment and any provider. Built from the `ifiokjr/secretspec` source branch with keyring support enabled on Linux.
+
+- **Binary:** `secretspec`
+- **License:** Apache-2.0
+- **Source:** <https://github.com/ifiokjr/secretspec>
+- **Homepage:** <https://secretspec.dev>
+
 ### solana-verify
 
 CLI tool for building verifiable Solana programs. Installs the upstream `solana-verify` binary from GitHub releases.
@@ -491,10 +579,10 @@ Run the repo updater to check every package for new upstream releases and refres
 
 The script updates:
 
-- GitHub release packages (version + platform hashes)
+- GitHub release packages (version + platform hashes, including `herdr`, `ironclaw`, `keyring`, `op`, and `pnpm`)
 - Homebrew-cask packages (`gpg-suite`, `nordvpn`, `zoom`)
 - Rolling URL packages (`steam`)
-- Rust packages built from source (`cargo-clean-all`, `cargo-interactive-update`, `dylint`, `knope`, `pina`, `sbpf-linker`)
+- Rust packages built from source (`cargo-clean-all`, `cargo-interactive-update`, `dylint`, `knope`, `pina`, `sbpf-linker`, `secretspec`)
 
 ### binary packages (pre-built)
 

--- a/scripts/update
+++ b/scripts/update
@@ -1359,7 +1359,7 @@ def update-prebuilt-package [
     fail $"could not parse version for ($package)"
   }
 
-  let has_fake_hashes = ($content | str contains "lib.fakeHash")
+  let has_fake_hashes = ($content | str contains "\" = lib.fakeHash;")
   if $current_version == $latest_version and not $has_fake_hashes {
     log-ok $package $"up to date \(v($current_version)\)"
     return false

--- a/scripts/update
+++ b/scripts/update
@@ -199,6 +199,15 @@ def github-api-get [url: string] {
   fail $"GitHub API request failed after retries for ($url): ($third.err)"
 }
 
+def crates-io-latest-version [crate: string] {
+  let data = (http get $"https://crates.io/api/v1/crates/($crate)")
+  let version = ($data | get -o crate.max_stable_version | default ($data | get -o crate.newest_version | default ""))
+  if ($version | is-empty) {
+    fail $"Failed to fetch latest crate version for ($crate)"
+  }
+  $version
+}
+
 def github-latest-tag [owner: string, repo: string] {
   let latest = (try {
     github-api-get $"https://api.github.com/repos/($owner)/($repo)/releases/latest" | get -o tag_name | default ""
@@ -1303,7 +1312,7 @@ def update-rolling-steam [packages_dir: string, dry_run: bool] {
 # These packages use binaries built by our CI and hosted in this repo.
 # Instead of updating hashes directly, we trigger the build-rust-prebuilt workflow.
 
-const PREBUILT_PACKAGES = ["dylint" "pina" "cargo-clean-all" "cargo-interactive-update" "sbpf-linker"]
+const PREBUILT_PACKAGES = ["dylint" "pina" "cargo-clean-all" "cargo-interactive-update" "keyring" "sbpf-linker"]
 
 def is-prebuilt-package [package: string] {
   $PREBUILT_PACKAGES | any {|p| $p == $package }
@@ -1350,14 +1359,19 @@ def update-prebuilt-package [
     fail $"could not parse version for ($package)"
   }
 
-  if $current_version == $latest_version {
+  let has_fake_hashes = ($content | str contains "lib.fakeHash")
+  if $current_version == $latest_version and not $has_fake_hashes {
     log-ok $package $"up to date \(v($current_version)\)"
     return false
   }
 
-  log-update $package $"v($current_version) → v($latest_version)"
+  if $current_version == $latest_version and $has_fake_hashes {
+    log-update $package $"v($current_version) hashes need prebuilt release"
+  } else {
+    log-update $package $"v($current_version) → v($latest_version)"
+  }
   if $dry_run {
-    log-sub "would trigger prebuilt build for v($latest_version)"
+    log-sub $"would trigger prebuilt build for v($latest_version)"
     return true
   }
 
@@ -1387,6 +1401,11 @@ def update-prebuilt-cargo-interactive [packages_dir: string, dry_run: bool] {
   let tag = (github-latest-tag "benjeau" "cargo-interactive-update")
   let latest_version = ($tag | str replace --regex '^v' '')
   update-prebuilt-package $packages_dir "cargo-interactive-update" $latest_version "benjeau" "cargo-interactive-update" $dry_run
+}
+
+def update-prebuilt-keyring [packages_dir: string, dry_run: bool] {
+  let latest_version = (crates-io-latest-version "keyring")
+  update-prebuilt-package $packages_dir "keyring" $latest_version "open-source-cooperative" "keyring-rs" $dry_run
 }
 
 def update-prebuilt-sbpf-linker [packages_dir: string, dry_run: bool] {
@@ -1504,6 +1523,7 @@ def main [
     { name: "gpg-suite", run: {|| update-gpg-suite $packages_dir $dry_run } }
     { name: "ironclaw", run: {|| update-ironclaw $packages_dir $dry_run } }
     { name: "kani", run: {|| update-kani $packages_dir $dry_run } }
+    { name: "keyring", run: {|| update-prebuilt-keyring $packages_dir $dry_run } }
     { name: "knope", run: {|| update-rust-knope $root $packages_dir $dry_run } }
     { name: "mdt", run: {|| update-mdt $packages_dir $dry_run } }
     { name: "monochange", run: {|| update-monochange $packages_dir $dry_run } }


### PR DESCRIPTION
## Summary
- add keyring CLI package using repo-hosted prebuilt binaries for macOS/Linux targets
- keep pinned source-build fallback with source hash and cargoHash
- extend prebuilt Rust workflow to build keyring artifacts and update raw fetchurl hashes
- add crates.io-driven update script support and docs entries

## Validation
- dprint check
- YAML parse for CI/prebuilt workflows
- nix build .#keyring --no-link
- nix run .#keyring -- --help
- nix run .#mdt -- check
- nix flake show --all-systems
- nu -c 'source scripts/update; update-prebuilt-keyring packages true'

## Prebuilt artifacts
Published via workflow run: https://github.com/ifiokjr/nixpkgs/actions/runs/26085528168
Release: https://github.com/ifiokjr/nixpkgs/releases/tag/prebuilt%2Fkeyring%2F4.0.1