### PR TITLE
feat(pnpm): update to 11.1.3, drop x86_64-darwin support

### DIFF
--- a/packages/pnpm-11/package.nix
+++ b/packages/pnpm-11/package.nix
@@ -2,13 +2,12 @@
 
 callPackage ../pnpm/common.nix {
   pname = "pnpm-11";
-  version = "11.0.4";
+  version = "11.1.3";
   description = "Fast, disk space efficient package manager (standalone, no Node.js dependency) — v11";
-  exeHash = "sha256-Vkf+hpA6Tim8eDSaPhI0Wwn1kUsMH8AAAXH6IBnWYRg=";
+  exeHash = "sha256-ZBcNHiw/PAr/nOGB6Yl9cIAFMKR4XTtBTmnJP57JQN8=";
   hashes = {
-    "x86_64-linux" = "sha256-gdUd4nPY4KVwBxcN6S0V/qBjMT7RBYmYstXWFl/7aKQ=";
-    "aarch64-linux" = "sha256-KuOBPaUgoc+eHbFMxQD/EcpoZPnRMT39gHv1zfTzN8M=";
-    "x86_64-darwin" = "sha256-WZlaKunniQHKbIqwyA9B4ddYodeyodODZGFSqf3f55o=";
-    "aarch64-darwin" = "sha256-tNbvgDQsCbs8D3y5+EE1Adp4wKZiP94AYTXTLBbt9OQ=";
+    "x86_64-linux" = "sha256-S68ERnZxOCdFThw0WSkD7pQn2PEWwybY+ZhijtCQNDM=";
+    "aarch64-linux" = "sha256-ZuEe91+e/kBK+i9ja1rBXfSS82ot2uX3NaHZAyD8Dco=";
+    "aarch64-darwin" = "sha256-q3REI0Ib8mRTkwmqWqn5fkVBpH6pZm3q1X3BzCiICqE=";
   };
 }

--- a/packages/pnpm/common.nix
+++ b/packages/pnpm/common.nix
@@ -452,12 +452,7 @@ stdenv.mkDerivation {
     inherit description;
     homepage = "https://pnpm.io/";
     license = licenses.mit;
-    platforms = [
-      "x86_64-linux"
-      "aarch64-linux"
-      "x86_64-darwin"
-      "aarch64-darwin"
-    ];
+    platforms = builtins.attrNames hashes;
     maintainers = [ ];
     mainProgram = "pnpm";
     tags = [

--- a/packages/pnpm/package.nix
+++ b/packages/pnpm/package.nix
@@ -2,13 +2,12 @@
 
 callPackage ./common.nix {
   pname = "pnpm";
-  version = "11.0.4";
+  version = "11.1.3";
   description = "Fast, disk space efficient package manager (standalone, no Node.js dependency)";
-  exeHash = "sha256-Vkf+hpA6Tim8eDSaPhI0Wwn1kUsMH8AAAXH6IBnWYRg=";
+  exeHash = "sha256-ZBcNHiw/PAr/nOGB6Yl9cIAFMKR4XTtBTmnJP57JQN8=";
   hashes = {
-    "x86_64-linux" = "sha256-gdUd4nPY4KVwBxcN6S0V/qBjMT7RBYmYstXWFl/7aKQ=";
-    "aarch64-linux" = "sha256-KuOBPaUgoc+eHbFMxQD/EcpoZPnRMT39gHv1zfTzN8M=";
-    "x86_64-darwin" = "sha256-WZlaKunniQHKbIqwyA9B4ddYodeyodODZGFSqf3f55o=";
-    "aarch64-darwin" = "sha256-tNbvgDQsCbs8D3y5+EE1Adp4wKZiP94AYTXTLBbt9OQ=";
+    "x86_64-linux" = "sha256-S68ERnZxOCdFThw0WSkD7pQn2PEWwybY+ZhijtCQNDM=";
+    "aarch64-linux" = "sha256-ZuEe91+e/kBK+i9ja1rBXfSS82ot2uX3NaHZAyD8Dco=";
+    "aarch64-darwin" = "sha256-q3REI0Ib8mRTkwmqWqn5fkVBpH6pZm3q1X3BzCiICqE=";
   };
 }

--- a/scripts/update
+++ b/scripts/update
@@ -770,10 +770,10 @@ def update-pnpm [packages_dir: string, dry_run: bool] {
 
   mut updated = (replace-version $content $latest_version)
 
+  # pnpm 11.1+ dropped Intel macOS (x86_64-darwin / macos-x64)
   let platform_entries = [
     { key: "x86_64-linux", url: $"https://registry.npmjs.org/@pnpm/linux-x64/-/linux-x64-($latest_version).tgz" }
     { key: "aarch64-linux", url: $"https://registry.npmjs.org/@pnpm/linux-arm64/-/linux-arm64-($latest_version).tgz" }
-    { key: "x86_64-darwin", url: $"https://registry.npmjs.org/@pnpm/macos-x64/-/macos-x64-($latest_version).tgz" }
     { key: "aarch64-darwin", url: $"https://registry.npmjs.org/@pnpm/macos-arm64/-/macos-arm64-($latest_version).tgz" }
   ]
   for entry in $platform_entries {
@@ -781,6 +781,9 @@ def update-pnpm [packages_dir: string, dry_run: bool] {
     let new_hash = (prefetch-sri $entry.url)
     $updated = (replace-key-hash $updated $entry.key $new_hash)
   }
+
+  # Remove x86_64-darwin hash line if present (dropped in 11.1+)
+  $updated = ($updated | str replace --regex '\n.*?"x86_64-darwin".*?\n' '\n')
 
   # Update exeHash if present (v11+)
   let current_exe_hash = (parse-capture $updated 'exeHash = "([^"]+)"')
@@ -829,10 +832,10 @@ def update-pnpm-11 [packages_dir: string, dry_run: bool] {
 
   mut updated = (replace-version $content $latest_version)
 
+  # pnpm 11.1+ dropped Intel macOS (x86_64-darwin / macos-x64)
   let platform_entries = [
     { key: "x86_64-linux", url: $"https://registry.npmjs.org/@pnpm/linux-x64/-/linux-x64-($latest_version).tgz" }
     { key: "aarch64-linux", url: $"https://registry.npmjs.org/@pnpm/linux-arm64/-/linux-arm64-($latest_version).tgz" }
-    { key: "x86_64-darwin", url: $"https://registry.npmjs.org/@pnpm/macos-x64/-/macos-x64-($latest_version).tgz" }
     { key: "aarch64-darwin", url: $"https://registry.npmjs.org/@pnpm/macos-arm64/-/macos-arm64-($latest_version).tgz" }
   ]
   for entry in $platform_entries {
@@ -840,6 +843,9 @@ def update-pnpm-11 [packages_dir: string, dry_run: bool] {
     let new_hash = (prefetch-sri $entry.url)
     $updated = (replace-key-hash $updated $entry.key $new_hash)
   }
+
+  # Remove x86_64-darwin hash line if present (dropped in 11.1+)
+  $updated = ($updated | str replace --regex '\n.*?"x86_64-darwin".*?\n' '\n')
 
   # Update exeHash
   log-sub "fetching exe..."


### PR DESCRIPTION
## Summary

pnpm 11.1+ no longer publishes Intel macOS (`macos-x64`) binaries. The `@pnpm/macos-x64` npm package stops at version 11.0.4.

### Changes
- Bump `pnpm` and `pnpm-11` from 11.0.4 → 11.1.3
- Remove `x86_64-darwin` from pnpm/pnpm-11 hashes (no binary available)
- `common.nix`: derive `meta.platforms` from `hashes` attr keys (pnpm-10 still has all 4 platforms)
- `scripts/update`: skip `macos-x64` for pnpm 11.1+ update functions, and remove stale `x86_64-darwin` hash lines

### Platform support
| Package | x86_64-linux | aarch64-linux | x86_64-darwin | aarch64-darwin |
|---------|-------------|--------------|--------------|---------------|
| pnpm (11.1.3) | ✅ | ✅ | ❌ dropped by upstream | ✅ |
| pnpm-11 (11.1.3) | ✅ | ✅ | ❌ dropped by upstream | ✅ |
| pnpm-10 (10.33.2) | ✅ | ✅ | ✅ | ✅ |