### PR TITLE
fix(op): use lib.optionals to avoid nested list in nativeBuildInputs

### DIFF
--- a/packages/op/package.nix
+++ b/packages/op/package.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation {
     installShellFiles
   ]
   ++ lib.optional stdenv.hostPlatform.isLinux autoPatchelfHook
-  ++ lib.optional stdenv.hostPlatform.isDarwin [
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
     xar
     cpio
   ];


### PR DESCRIPTION
Fixes Nixpkgs 26.05 deprecation warning about nested lists in `nativeBuildInputs`.

`lib.optional` with a list arg wraps it in another list → `[ installShellFiles [ xar cpio ] ]`.
`lib.optionals` concatenates the list → `[ installShellFiles xar cpio ]`.