### PR TITLE
feat(agave): add solana alias, make agave default to 3_1, fix pagination bug

### DIFF
--- a/docs/packages.md
+++ b/docs/packages.md
@@ -4,36 +4,36 @@ This flake exposes packages through both `packages.${system}` and `overlays.defa
 
 ## catalog
 
-| Package                                                                               | Platforms              | Notes                                                        |
-| ------------------------------------------------------------------------------------- | ---------------------- | ------------------------------------------------------------ |
-| `agave`, `agave-4_0`, `agave-3_1`, `agave-3_0`, `agave-2_3`, `agave-2_2`, `agave-2_1` | linux x64, macOS       | Agave/Solana validator client and CLI tracks                 |
-| `cargo-clean-all`                                                                     | linux, macOS           | Recursively clean Cargo project targets                      |
-| `cargo-interactive-update`                                                            | linux, macOS           | Interactively update Cargo dependencies                      |
-| `codex-cli`                                                                           | linux, macOS           | OpenAI Codex CLI                                             |
-| `deno`                                                                                | linux, macOS           | Deno runtime from pre-built releases                         |
-| `dylint`                                                                              | linux, macOS           | Rust lint tooling                                            |
-| `godot`                                                                               | linux, macOS           | Godot editor/launcher from upstream binaries                 |
-| `gpg-suite`                                                                           | macOS                  | GPG Suite app bundle                                         |
-| `herdr`                                                                               | linux, macOS           | Terminal agent multiplexer                                   |
-| `ironclaw`                                                                            | linux, macOS           | NEAR AI Agent OS                                             |
-| `kani`                                                                                | linux, macOS           | Rust model checker                                           |
-| `keyring`                                                                             | linux, macOS           | Rust Keyring CLI; repo-hosted prebuilts with source fallback |
-| `knope`                                                                               | linux, macOS           | Release/changelog/version automation                         |
-| `mdt`                                                                                 | linux, macOS           | Markdown templating updater                                  |
-| `monochange`                                                                          | linux, macOS           | Monorepo version and release manager                         |
-| `nordvpn`                                                                             | macOS                  | NordVPN client                                               |
-| `ollama`                                                                              | linux, macOS           | Local LLM CLI/app                                            |
-| `op`                                                                                  | linux, macOS           | 1Password CLI beta channel                                   |
-| `pina`                                                                                | linux, macOS           | Solana smart contract framework CLI                          |
-| `pnpm`, `pnpm-11`, `pnpm-10`, `pnpm-standalone`                                       | linux, macOS           | Standalone pnpm tracks and compatibility alias               |
-| `racket-minimal`                                                                      | linux, macOS           | Minimal Racket distribution                                  |
-| `sbpf-linker`                                                                         | macOS                  | SBPF linker                                                  |
-| `secretspec`                                                                          | linux, macOS           | Declarative secrets CLI                                      |
-| `solana-verify`                                                                       | linux x64, macOS arm64 | Verifiable Solana builds                                     |
-| `steam`                                                                               | macOS                  | Steam app bundle                                             |
-| `surfpool`                                                                            | linux x64, macOS       | Solana test-validator replacement                            |
-| `wait-for-them`                                                                       | linux x64, macOS x64   | TCP/HTTP readiness helper                                    |
-| `zoom`                                                                                | macOS                  | Zoom client                                                  |
+| Package                                                                                                      | Platforms              | Notes                                                        |
+| ------------------------------------------------------------------------------------------------------------ | ---------------------- | ------------------------------------------------------------ |
+| `agave`, `solana`, `agave-4_0`, `agave-3_1`, `agave-3_0`, `agave-2_3`, `agave-2_2`, `agave-2_1`, `agave-2_0` | linux x64, macOS       | Agave/Solana validator client and CLI tracks                 |
+| `cargo-clean-all`                                                                                            | linux, macOS           | Recursively clean Cargo project targets                      |
+| `cargo-interactive-update`                                                                                   | linux, macOS           | Interactively update Cargo dependencies                      |
+| `codex-cli`                                                                                                  | linux, macOS           | OpenAI Codex CLI                                             |
+| `deno`                                                                                                       | linux, macOS           | Deno runtime from pre-built releases                         |
+| `dylint`                                                                                                     | linux, macOS           | Rust lint tooling                                            |
+| `godot`                                                                                                      | linux, macOS           | Godot editor/launcher from upstream binaries                 |
+| `gpg-suite`                                                                                                  | macOS                  | GPG Suite app bundle                                         |
+| `herdr`                                                                                                      | linux, macOS           | Terminal agent multiplexer                                   |
+| `ironclaw`                                                                                                   | linux, macOS           | NEAR AI Agent OS                                             |
+| `kani`                                                                                                       | linux, macOS           | Rust model checker                                           |
+| `keyring`                                                                                                    | linux, macOS           | Rust Keyring CLI; repo-hosted prebuilts with source fallback |
+| `knope`                                                                                                      | linux, macOS           | Release/changelog/version automation                         |
+| `mdt`                                                                                                        | linux, macOS           | Markdown templating updater                                  |
+| `monochange`                                                                                                 | linux, macOS           | Monorepo version and release manager                         |
+| `nordvpn`                                                                                                    | macOS                  | NordVPN client                                               |
+| `ollama`                                                                                                     | linux, macOS           | Local LLM CLI/app                                            |
+| `op`                                                                                                         | linux, macOS           | 1Password CLI beta channel                                   |
+| `pina`                                                                                                       | linux, macOS           | Solana smart contract framework CLI                          |
+| `pnpm`, `pnpm-11`, `pnpm-10`, `pnpm-standalone`                                                              | linux, macOS           | Standalone pnpm tracks and compatibility alias               |
+| `racket-minimal`                                                                                             | linux, macOS           | Minimal Racket distribution                                  |
+| `sbpf-linker`                                                                                                | macOS                  | SBPF linker                                                  |
+| `secretspec`                                                                                                 | linux, macOS           | Declarative secrets CLI                                      |
+| `solana-verify`                                                                                              | linux x64, macOS arm64 | Verifiable Solana builds                                     |
+| `steam`                                                                                                      | macOS                  | Steam app bundle                                             |
+| `surfpool`                                                                                                   | linux x64, macOS       | Solana test-validator replacement                            |
+| `wait-for-them`                                                                                              | linux x64, macOS x64   | TCP/HTTP readiness helper                                    |
+| `zoom`                                                                                                       | macOS                  | Zoom client                                                  |
 
 ## usage
 

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,9 @@
     }:
     {
       overlays.default = final: _prev: rec {
-        agave = final.callPackage ./packages/agave/package.nix { };
+        agave = final.agave-3_1;
+        solana = final.agave;
+        agave-2_0 = final.callPackage ./packages/agave-2_0/package.nix { };
         agave-2_1 = final.callPackage ./packages/agave-2_1/package.nix { };
         agave-2_2 = final.callPackage ./packages/agave-2_2/package.nix { };
         agave-2_3 = final.callPackage ./packages/agave-2_3/package.nix { };
@@ -63,7 +65,9 @@
         lib = pkgs.lib;
 
         packages = rec {
-          agave = pkgs.callPackage ./packages/agave/package.nix { };
+          agave = agave-3_1;
+          solana = agave;
+          agave-2_0 = pkgs.callPackage ./packages/agave-2_0/package.nix { };
           agave-2_1 = pkgs.callPackage ./packages/agave-2_1/package.nix { };
           agave-2_2 = pkgs.callPackage ./packages/agave-2_2/package.nix { };
           agave-2_3 = pkgs.callPackage ./packages/agave-2_3/package.nix { };

--- a/mdt.toml
+++ b/mdt.toml
@@ -1,6 +1,7 @@
 [data]
 v = { command = "./scripts/versions", format = "json", watch = [
 	"packages/agave/package.nix",
+	"packages/agave-2_0/package.nix",
 	"packages/agave-2_1/package.nix",
 	"packages/agave-2_2/package.nix",
 	"packages/agave-2_3/package.nix",

--- a/packages/agave-2_0/package.nix
+++ b/packages/agave-2_0/package.nix
@@ -1,0 +1,35 @@
+{
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  makeWrapper,
+  lib,
+  zlib,
+  openssl,
+  udev,
+}:
+
+let
+  version = "2.0.21";
+
+  hashes = {
+    "aarch64-apple-darwin" = "sha256-zJAzm3eaGvspk6nd6j8600d0JqUbxl/EXXMnvglSNWY=";
+    "x86_64-apple-darwin" = "sha256-6VBBubSHkJ4XakBqwsOFx3vApn02VgYI8DeNg2k8kxE=";
+    "x86_64-unknown-linux-gnu" = "sha256-44w3SDSkHNmjPvww7gBqXOpdS7sSx41wRmaGQIWoRyg=";
+  };
+in
+import ../agave/common.nix {
+  inherit
+    stdenv
+    fetchurl
+    autoPatchelfHook
+    makeWrapper
+    lib
+    zlib
+    openssl
+    udev
+    version
+    hashes
+    ;
+  pname = "agave-2_0";
+}

--- a/packages/agave-4_0/package.nix
+++ b/packages/agave-4_0/package.nix
@@ -10,12 +10,12 @@
 }:
 
 let
-  version = "4.0.0-beta.7";
+  version = "4.0.0";
 
   hashes = {
-    "aarch64-apple-darwin" = "sha256-nCph542fw4hY+z7lgN7X6t2kq7FG5ojANUSvRGs3URo=";
-    "x86_64-apple-darwin" = "sha256-y8aYBpdfWL5UBJxYnRmkDzcydSjDrCvW41ndNAourEE=";
-    "x86_64-unknown-linux-gnu" = "sha256-7PeBEF0vPOX0c6CCw6w9NKhl3uUXMUuUTUrmuASVExE=";
+    "aarch64-apple-darwin" = "sha256-eRln77dFyV+PaHaJIy6JV40rVAGJveLJnemHlPBoT/U=";
+    "x86_64-apple-darwin" = "sha256-THsS0arYSmksetN0yKN+ViVc6CvMq2iwKl5AvDstQSE=";
+    "x86_64-unknown-linux-gnu" = "sha256-yDm6Yp0Q7dX5mvaIB9wllI/OYs1RdrVq0T4j91Yu9PI=";
   };
 in
 import ../agave/common.nix {

--- a/packages/agave/package.nix
+++ b/packages/agave/package.nix
@@ -1,34 +1,5 @@
 {
-  stdenv,
-  fetchurl,
-  autoPatchelfHook,
-  makeWrapper,
-  lib,
-  zlib,
-  openssl,
-  udev,
+  callPackage,
 }:
 
-let
-  version = "4.0.0";
-
-  hashes = {
-    "aarch64-apple-darwin" = "sha256-eRln77dFyV+PaHaJIy6JV40rVAGJveLJnemHlPBoT/U=";
-    "x86_64-apple-darwin" = "sha256-THsS0arYSmksetN0yKN+ViVc6CvMq2iwKl5AvDstQSE=";
-    "x86_64-unknown-linux-gnu" = "sha256-yDm6Yp0Q7dX5mvaIB9wllI/OYs1RdrVq0T4j91Yu9PI=";
-  };
-in
-import ./common.nix {
-  inherit
-    stdenv
-    fetchurl
-    autoPatchelfHook
-    makeWrapper
-    lib
-    zlib
-    openssl
-    udev
-    version
-    hashes
-    ;
-}
+callPackage ./agave-3_1/package.nix { }

--- a/readme.md
+++ b/readme.md
@@ -8,12 +8,13 @@ Additional Nix packages not yet available in [nixpkgs](https://github.com/NixOS/
 
 | Package                                               | Version                                                                                                              | Platforms                  | Description                                                                   |
 | ----------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- | -------------------------- | ----------------------------------------------------------------------------- |
-| [agave](#agave)                                       | <!-- {~v_agave:"{{ v.agave }}"} -->4.0.0<!-- {/v_agave} -->                                                          | linux (x64), macos         | Solana validator client and CLI toolchain by Anza (latest 3.1.x track)        |
-| [agave-4_0](#agave)                                   | <!-- {~v_agave_4_0:"{{ v.agave_4_0 }}"} -->4.0.0-beta.7<!-- {/v_agave_4_0} -->                                       | linux (x64), macos         | Agave pinned to the latest 4.0.x release                                      |
+| [agave](#agave)                                       | <!-- {~v_agave:"{{ v.agave_3_1 }}"} -->3.1.14<!-- {/v_agave} -->                                                     | linux (x64), macos         | Solana validator client and CLI toolchain by Anza (alias for agave-3_1)       |
+| [agave-4_0](#agave)                                   | <!-- {~v_agave_4_0:"{{ v.agave_4_0 }}"} -->4.0.0<!-- {/v_agave_4_0} -->                                              | linux (x64), macos         | Agave pinned to the latest 4.0.x release                                      |
 | [agave-3_1](#agave)                                   | <!-- {~v_agave_3_1:"{{ v.agave }}"} -->4.0.0<!-- {/v_agave_3_1} -->                                                  | linux (x64), macos         | Agave pinned to the latest 3.1.x release                                      |
 | [agave-3_0](#agave)                                   | <!-- {~v_agave_3_0:"{{ v.agave_3_0 }}"} -->3.0.14<!-- {/v_agave_3_0} -->                                             | linux (x64), macos         | Agave pinned to the latest 3.0.x release                                      |
 | [agave-2_3](#agave)                                   | <!-- {~v_agave_2_3:"{{ v.agave_2_3 }}"} -->2.3.13<!-- {/v_agave_2_3} -->                                             | linux (x64), macos         | Agave pinned to the latest 2.3.x release                                      |
 | [agave-2_2](#agave)                                   | <!-- {~v_agave_2_2:"{{ v.agave_2_2 }}"} -->2.2.20<!-- {/v_agave_2_2} -->                                             | linux (x64), macos         | Agave pinned to the latest 2.2.x release                                      |
+| [agave-2_0](#agave)                                   | <!-- {~v_agave_2_0:"{{ v.agave_2_0 }}"} -->2.0.21<!-- {/v_agave_2_0} -->                                             | linux (x64), macos         | Agave pinned to the latest 2.0.x release                                      |
 | [agave-2_1](#agave)                                   | <!-- {~v_agave_2_1:"{{ v.agave_2_1 }}"} -->2.1.21<!-- {/v_agave_2_1} -->                                             | linux (x64), macos         | Agave pinned to the latest 2.1.x release                                      |
 | [cargo-clean-all](#cargo-clean-all)                   | <!-- {~v_cargo_clean_all:"{{ v.cargo_clean_all }}"} -->0.6.4<!-- {/v_cargo_clean_all} -->                            | linux, macos               | Recursively clean Cargo projects in a directory that match selected criteria  |
 | [cargo-interactive-update](#cargo-interactive-update) | <!-- {~v_cargo_interactive_update:"{{ v.cargo_interactive_update }}"} -->0.6.2<!-- {/v_cargo_interactive_update} --> | linux, macos               | A cargo extension to update direct dependencies interactively                 |
@@ -40,6 +41,7 @@ Additional Nix packages not yet available in [nixpkgs](https://github.com/NixOS/
 | [racket-minimal](#racket-minimal)                     | <!-- {~v_racket_minimal:"{{ v.racket_minimal }}"} -->9.1<!-- {/v_racket_minimal} -->                                 | linux, macos               | Racket programming language (minimal distribution, pre-built)                 |
 | [sbpf-linker](#sbpf-linker)                           | <!-- {~v_sbpf_linker:"{{ v.sbpf_linker }}"} -->0.1.8<!-- {/v_sbpf_linker} -->                                        | macos                      | Upstream BPF linker for SBPF V0 programs                                      |
 | [secretspec](#secretspec)                             | <!-- {~v_secretspec:"{{ v.secretspec }}"} -->0.10.1<!-- {/v_secretspec} -->                                          | linux, macos               | Declarative secrets, every environment, any provider                          |
+| [solana](#agave)                                      | <!-- {~v_solana:"{{ v.agave_3_1 }}"} -->3.1.14<!-- {/v_solana} -->                                                   | linux (x64), macos         | Alias for agave-3_1 (Solana validator client and CLI)                         |
 | [solana-verify](#solana-verify)                       | <!-- {~v_solana_verify:"{{ v.solana_verify }}"} -->0.4.15<!-- {/v_solana_verify} -->                                 | linux (x64), macos (arm64) | CLI tool for building verifiable Solana programs                              |
 | [steam](#steam)                                       | <!-- {~v_steam:"{{ v.steam }}"} -->4.0<!-- {/v_steam} -->                                                            | macos                      | Steam video game digital distribution service                                 |
 | [surfpool](#surfpool)                                 | <!-- {~v_surfpool:"{{ v.surfpool }}"} -->1.2.1<!-- {/v_surfpool} -->                                                 | linux (x64), macos         | A drop-in replacement for solana-test-validator with mainnet state simulation |
@@ -267,12 +269,14 @@ Solana validator client and CLI toolchain by Anza. Pre-built binary from GitHub 
 - **License:** Apache-2.0
 - **Source:** <https://github.com/anza-xyz/agave>
 - **Tracks:**
-  - `agave` (latest 3.1.x)
+  - `agave` (latest 3.1.x, alias: `solana`)
+  - `agave-4_0`
   - `agave-3_1`
   - `agave-3_0`
   - `agave-2_3`
   - `agave-2_2`
   - `agave-2_1`
+  - `agave-2_0`
 
 Examples:
 

--- a/scripts/update
+++ b/scripts/update
@@ -253,18 +253,43 @@ def replace-rev [content: string, new_rev: string] {
 }
 
 def github-latest-tag-with-prefix [owner: string, repo: string, prefix: string] {
-  let tags = try {
-    github-api-get $"https://api.github.com/repos/($owner)/($repo)/tags?per_page=100"
-  } catch {
-    fail $"Failed to fetch tags for ($owner)/($repo)"
-  }
+  let headers = (github-headers)
+  mut page = 1
+  mut matched = ""
 
-  let matched = (
-    $tags
-    | where {|tag| $tag.name | str starts-with $prefix }
-    | get -o 0.name
-    | default ""
-  )
+  loop {
+    let tags = try {
+      if ($headers | is-empty) {
+        http get $"https://api.github.com/repos/($owner)/($repo)/tags?per_page=100&page=($page)"
+      } else {
+        http get -H $headers $"https://api.github.com/repos/($owner)/($repo)/tags?per_page=100&page=($page)"
+      }
+    } catch {
+      fail $"Failed to fetch tags for ($owner)/($repo) (page ($page))"
+    }
+
+    if ($tags | is-empty) {
+      break
+    }
+
+    let found = (
+      $tags
+      | where {|tag| $tag.name | str starts-with $prefix }
+      | get -o 0.name
+      | default ""
+    )
+
+    if ($found | is-not-empty) {
+      $matched = $found
+      break
+    }
+
+    if ($tags | length) < 100 {
+      break
+    }
+
+    $page += 1
+  }
 
   if ($matched | is-empty) {
     fail $"No tag with prefix \"($prefix)\" for ($owner)/($repo)"
@@ -274,18 +299,43 @@ def github-latest-tag-with-prefix [owner: string, repo: string, prefix: string] 
 }
 
 def github-latest-stable-tag [owner: string, repo: string] {
-  let tags = try {
-    github-api-get $"https://api.github.com/repos/($owner)/($repo)/tags?per_page=100"
-  } catch {
-    fail $"Failed to fetch tags for ($owner)/($repo)"
-  }
+  let headers = (github-headers)
+  mut page = 1
+  mut matched = ""
 
-  let matched = (
-    $tags
-    | where {|tag| ($tag.name | str starts-with "v") and not ($tag.name | str contains "-") }
-    | get -o 0.name
-    | default ""
-  )
+  loop {
+    let tags = try {
+      if ($headers | is-empty) {
+        http get $"https://api.github.com/repos/($owner)/($repo)/tags?per_page=100&page=($page)"
+      } else {
+        http get -H $headers $"https://api.github.com/repos/($owner)/($repo)/tags?per_page=100&page=($page)"
+      }
+    } catch {
+      fail $"Failed to fetch tags for ($owner)/($repo) (page ($page))"
+    }
+
+    if ($tags | is-empty) {
+      break
+    }
+
+    let found = (
+      $tags
+      | where {|tag| ($tag.name | str starts-with "v") and not ($tag.name | str contains "-") }
+      | get -o 0.name
+      | default ""
+    )
+
+    if ($found | is-not-empty) {
+      $matched = $found
+      break
+    }
+
+    if ($tags | length) < 100 {
+      break
+    }
+
+    $page += 1
+  }
 
   if ($matched | is-empty) {
     fail $"No stable tag found for ($owner)/($repo)"
@@ -656,8 +706,12 @@ def update-agave [packages_dir: string, dry_run: bool] {
   update-agave-package $packages_dir "agave" $latest_version $dry_run
 }
 
+def update-agave-2-0 [packages_dir: string, dry_run: bool] {
+  update-agave-track $packages_dir "agave-2_0" "2.0" $dry_run
+}
+
 def update-agave-4-0 [packages_dir: string, dry_run: bool] {
-  update-agave-beta-track $packages_dir "agave-4_0" "4.0" $dry_run
+  update-agave-track $packages_dir "agave-4_0" "4.0" $dry_run
 }
 
 def update-agave-3-1 [packages_dir: string, dry_run: bool] {
@@ -1508,6 +1562,7 @@ def main [
 
   mut steps = [
     { name: "agave", run: {|| update-agave $packages_dir $dry_run } }
+    { name: "agave-2_0", run: {|| update-agave-2-0 $packages_dir $dry_run } }
     { name: "agave-2_1", run: {|| update-agave-2-1 $packages_dir $dry_run } }
     { name: "agave-2_2", run: {|| update-agave-2-2 $packages_dir $dry_run } }
     { name: "agave-2_3", run: {|| update-agave-2-3 $packages_dir $dry_run } }


### PR DESCRIPTION
## Summary

- **Add `solana` alias** pointing to `agave` (which defaults to agave-3_1)
- **Make `agave` default** track `agave-3_1` instead of latest stable
- **Re-add `agave-2_0`** at v2.0.21 — was previously removed due to a pagination bug in the update script
- **Update `agave-4_0`** from v4.0.0-beta.7 to v4.0.0 stable
- **Update `agave-4_0` updater** from beta track to stable track
- **Fix pagination bug** in `github-latest-tag-with-prefix` and `github-latest-stable-tag` — both functions now paginate through all GitHub tag pages instead of only checking the first 100 tags

### Root cause of agave-2_0 failure

The `anza-xyz/agave` repo has 200+ tags. The old `github-latest-tag-with-prefix` function only fetched `?per_page=100`, so v2.0.x tags (beyond the first page) were never found. The fix adds page-based pagination that continues fetching until a match is found or all pages are exhausted.