### PR TITLE
feat(ccase): add ccase CLI package with prebuilt+sourceBuild pattern

### DIFF
--- a/.github/workflows/build-rust-prebuilt.yml
+++ b/.github/workflows/build-rust-prebuilt.yml
@@ -14,6 +14,7 @@ on:
           - cargo-interactive-update
           - sbpf-linker
           - keyring
+          - ccase
       version:
         description: "Version to build (without v prefix)"
         required: true
@@ -76,6 +77,11 @@ jobs:
             keyring)
               echo "repo=open-source-cooperative/keyring-rs" >> "$GITHUB_OUTPUT"
               echo "bin=keyring" >> "$GITHUB_OUTPUT"
+              ;;
+            ccase)
+              echo "repo=stringcase/ccase" >> "$GITHUB_OUTPUT"
+              echo "bin=ccase" >> "$GITHUB_OUTPUT"
+              echo "ref=${VERSION}" >> "$GITHUB_OUTPUT"
               ;;
           esac
 

--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,7 @@
         agave-3_1 = final.callPackage ./packages/agave-3_1/package.nix { };
         agave-4_0 = final.callPackage ./packages/agave-4_0/package.nix { };
         cargo-clean-all = final.callPackage ./packages/cargo-clean-all/package.nix { };
+        ccase = final.callPackage ./packages/ccase/package.nix { };
         dylint = final.callPackage ./packages/dylint/package.nix { };
         cargo-interactive-update = final.callPackage ./packages/cargo-interactive-update/package.nix { };
         codex-cli = final.callPackage ./packages/codex-cli/package.nix { };
@@ -75,6 +76,7 @@
           agave-3_1 = pkgs.callPackage ./packages/agave-3_1/package.nix { };
           agave-4_0 = pkgs.callPackage ./packages/agave-4_0/package.nix { };
           cargo-clean-all = pkgs.callPackage ./packages/cargo-clean-all/package.nix { };
+          ccase = pkgs.callPackage ./packages/ccase/package.nix { };
           dylint = pkgs.callPackage ./packages/dylint/package.nix { };
           cargo-interactive-update = pkgs.callPackage ./packages/cargo-interactive-update/package.nix { };
           codex-cli = pkgs.callPackage ./packages/codex-cli/package.nix { };

--- a/packages/ccase/package.nix
+++ b/packages/ccase/package.nix
@@ -1,0 +1,98 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  fetchFromGitHub,
+  rustPlatform,
+  autoPatchelfHook,
+}:
+
+let
+  version = "0.5.1";
+
+  platformSuffix =
+    {
+      "aarch64-darwin" = "aarch64-apple-darwin";
+      "x86_64-darwin" = "x86_64-apple-darwin";
+      "aarch64-linux" = "aarch64-unknown-linux-gnu";
+      "x86_64-linux" = "x86_64-unknown-linux-gnu";
+    }
+    .${stdenv.hostPlatform.system} or (throw "Unsupported platform: ${stdenv.hostPlatform.system}");
+
+  hashes = {
+    "aarch64-apple-darwin" = lib.fakeHash;
+    "x86_64-apple-darwin" = lib.fakeHash;
+    "aarch64-unknown-linux-gnu" = lib.fakeHash;
+    "x86_64-unknown-linux-gnu" = lib.fakeHash;
+  };
+
+  prebuiltHash = hashes.${platformSuffix} or lib.fakeHash;
+  hasPrebuilt = prebuiltHash != lib.fakeHash;
+
+  meta = {
+    description = "Command line interface to convert strings into any case";
+    homepage = "https://github.com/stringcase/ccase";
+    license = lib.licenses.mit;
+    mainProgram = "ccase";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+    tags = [
+      "cli"
+    ];
+  };
+
+  src = fetchFromGitHub {
+    owner = "stringcase";
+    repo = "ccase";
+    rev = version;
+    hash = "sha256-VkykOOMHUsJhfktNRfHx+kvB2331PPhT5pW5bX+kLng=";
+  };
+
+  sourceBuild = rustPlatform.buildRustPackage {
+    pname = "ccase";
+    inherit version src;
+    cargoHash = "sha256-gi7CR5UUD+qUQ6wx0XepzyHHq9RH7SnsMXIKV4JoiQg=";
+    doCheck = false;
+    doInstallCheck = true;
+    installCheckPhase = "$out/bin/ccase --help > /dev/null";
+    meta = meta // {
+      sourceProvenance = [ lib.sourceTypes.fromSource ];
+    };
+  };
+
+  prebuilt = stdenv.mkDerivation {
+    pname = "ccase";
+    inherit version;
+    src = fetchurl {
+      url = "https://github.com/ifiokjr/nixpkgs/releases/download/prebuilt/ccase/${version}/ccase-${platformSuffix}.tar.gz";
+      hash = prebuiltHash;
+    };
+    dontUnpack = true;
+    dontBuild = true;
+    dontStrip = true;
+    nativeBuildInputs = lib.optionals stdenv.isLinux [ autoPatchelfHook ];
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/bin
+      tar xzf $src -C $out/bin/
+      chmod +x $out/bin/ccase
+
+      runHook postInstall
+    '';
+    doInstallCheck = true;
+    installCheckPhase = ''
+      runHook preInstallCheck
+      $out/bin/ccase --help > /dev/null
+      runHook postInstallCheck
+    '';
+    meta = meta // {
+      sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    };
+  };
+in
+if hasPrebuilt then prebuilt else sourceBuild


### PR DESCRIPTION
Add the `ccase` CLI tool from https://github.com/stringcase/ccase for converting strings between cases (snake_case, camelCase, etc.).

**Package details:**
- Version: 0.5.1
- License: MIT
- Pattern: prebuilt+sourceBuild (downloads prebuilt binary when available, falls back to source build)
- Tag format: bare version (`0.5.1`) — like `cargo-interactive-update`
- Source build verified: ✅ builds and runs correctly

**Changes:**
- `packages/ccase/package.nix` — new package definition
- `flake.nix` — added ccase to overlay and packages
- `.github/workflows/build-rust-prebuilt.yml` — added ccase to build matrix

Prebuilt hashes are set to `lib.fakeHash` — once the workflow is run to create a release, the `update-package` step will fill in the real hashes.

**Code review summary:** The ccase source is clean — a simple CLI using clap and convert_case crates. No network calls, no filesystem access beyond stdin/stdout, no unsafe code. Safe for distribution as a prebuilt binary.