### PR TITLE
fix(ccase): add gcc.cc.cc.lib as buildInputs for Linux

### DIFF
--- a/packages/ccase/package.nix
+++ b/packages/ccase/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  gcc,
   fetchurl,
   fetchFromGitHub,
   rustPlatform,
@@ -74,6 +75,7 @@ let
     dontUnpack = true;
     dontBuild = true;
     dontStrip = true;
+    buildInputs = lib.optionals stdenv.isLinux [ gcc.cc.cc.lib ];
     nativeBuildInputs = lib.optionals stdenv.isLinux [ autoPatchelfHook ];
     installPhase = ''
       runHook preInstall


### PR DESCRIPTION
The prebuilt ccase binary on Linux needs libgcc_s.so.1 which autoPatchelfHook cannot find without an explicit dependency.

This fixes the CI failure in ifiokjr/dotfiles where home-manager activation fails on x86_64-linux with:
```
auto-patchelf: 1 dependencies could not be satisfied
error: auto-patchelf could not satisfy dependency libgcc_s.so.1
```