### PR TITLE
feat(pnpm): configure mutable state defaults

### DIFF
--- a/docs/packages.md
+++ b/docs/packages.md
@@ -71,3 +71,5 @@ in {
 - `pnpm-11` tracks the latest v11 release and uses `pnpm runtime set node` in `pnpm-activate-env`.
 - `pnpm-10` tracks the latest v10 release and uses `pnpm env add --global` in `pnpm-activate-env`.
 - `pnpm-standalone` is a compatibility alias for `pnpm`.
+- The wrapper sets `PNPM_HOME` when unset so PNPM-managed Node runtimes, global bins, and the package store live in mutable user state outside `/nix/store`.
+- Default `PNPM_HOME` is `$XDG_DATA_HOME/pnpm`, `~/Library/pnpm` on macOS, or `~/.local/share/pnpm` on Linux; user-provided `PNPM_HOME` is preserved.

--- a/packages/pnpm/common.nix
+++ b/packages/pnpm/common.nix
@@ -89,20 +89,31 @@ stdenv.mkDerivation {
     cp -r . $out/libexec/pnpm/
     chmod +x $out/libexec/pnpm/pnpm
 
+    install -m 644 ${./pnpm-default-env.sh} $out/libexec/pnpm-default-env
+    substituteInPlace $out/libexec/pnpm-default-env \
+      --replace-fail '@PNPM_USE_RUNTIME_COMMAND@' '${if useRuntimeCommand then "1" else "0"}'
+
     ${
       if stdenv.isLinux then
         ''
           INTERP=$(cat $NIX_CC/nix-support/dynamic-linker)
-          makeWrapper "$INTERP" $out/bin/pnpm \
-            --add-flags "$out/libexec/pnpm/pnpm" \
-            --set _REAL_EXE "$out/libexec/pnpm/pnpm" \
-            --set LD_PRELOAD "${fixExePath}/lib/fixexe.so" \
-            --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ stdenv.cc.cc.lib ]}"
+          cat > $out/bin/pnpm <<EOF
+          #!${stdenv.shell}
+          . "$out/libexec/pnpm-default-env"
+          pnpm_prepend_global_bin
+          export _REAL_EXE="$out/libexec/pnpm/pnpm"
+          export LD_PRELOAD="${fixExePath}/lib/fixexe.so"
+          export LD_LIBRARY_PATH="${lib.makeLibraryPath [ stdenv.cc.cc.lib ]}:\''${LD_LIBRARY_PATH:-}"
+          exec "$INTERP" "$out/libexec/pnpm/pnpm" "\$@"
+          EOF
+          chmod +x $out/bin/pnpm
         ''
       else
         ''
           cat > $out/bin/pnpm <<EOF
           #!${stdenv.shell}
+          . "$out/libexec/pnpm-default-env"
+          pnpm_prepend_global_bin
           exec "$out/libexec/pnpm/pnpm" "\$@"
           EOF
           chmod +x $out/bin/pnpm
@@ -122,30 +133,9 @@ stdenv.mkDerivation {
     patchShebangs $out/bin/pnpm-activate-env
 
     mkdir -p $out/nix-support
-    cat > $out/nix-support/setup-hook <<'EOF'
-    if [ -z "''${PNPM_HOME:-}" ]; then
-      if [ -n "''${XDG_DATA_HOME:-}" ]; then
-        export PNPM_HOME="''${XDG_DATA_HOME}/pnpm"
-      elif [ -n "''${HOME:-}" ] && [ "''${HOME}" != /homeless-shelter ]; then
-        case "$(uname -s)" in
-          Darwin)
-            export PNPM_HOME="''${HOME}/Library/pnpm"
-            ;;
-          *)
-            export PNPM_HOME="''${HOME}/.local/share/pnpm"
-            ;;
-        esac
-      fi
-    fi
-
-    if [ -n "''${PNPM_HOME:-}" ]; then
-      PNPM_GLOBAL_BIN="''${PNPM_HOME}${if useRuntimeCommand then "/bin" else ""}"
-      case ":''${PATH:-}:" in
-        *":''${PNPM_GLOBAL_BIN}:"*) ;;
-        *) export PATH="''${PNPM_GLOBAL_BIN}:''${PATH:-}" ;;
-      esac
-      unset PNPM_GLOBAL_BIN
-    fi
+    cat > $out/nix-support/setup-hook <<EOF
+    . "$out/libexec/pnpm-default-env"
+    pnpm_prepend_global_bin
     EOF
 
     runHook postInstall
@@ -163,6 +153,55 @@ stdenv.mkDerivation {
         cd "$WORK"
         $out/bin/pnpm init
         test -f package.json
+
+        echo "Checking pnpm wrapper mutable state defaults..."
+        WRAPPER_ROOT=$(mktemp -d)
+        WRAPPER_GLOBAL_SUFFIX="${if useRuntimeCommand then "/bin" else ""}"
+        (
+          export HOME="$WRAPPER_ROOT/home"
+          unset PNPM_HOME XDG_DATA_HOME
+          case "$(uname -s)" in
+            Darwin)
+              expected_pnpm_home="$HOME/Library/pnpm"
+              ;;
+            *)
+              expected_pnpm_home="$HOME/.local/share/pnpm"
+              ;;
+          esac
+
+          store_path="$($out/bin/pnpm store path)"
+          test "$store_path" = "$expected_pnpm_home/store/v${lib.versions.major version}"
+          test -d "$expected_pnpm_home"
+          test -d "$expected_pnpm_home$WRAPPER_GLOBAL_SUFFIX"
+        )
+        (
+          export HOME="$WRAPPER_ROOT/home"
+          export XDG_DATA_HOME="$WRAPPER_ROOT/xdg-data"
+          unset PNPM_HOME
+          store_path="$($out/bin/pnpm store path)"
+          test "$store_path" = "$XDG_DATA_HOME/pnpm/store/v${lib.versions.major version}"
+          test -d "$XDG_DATA_HOME/pnpm"
+          test -d "$XDG_DATA_HOME/pnpm$WRAPPER_GLOBAL_SUFFIX"
+        )
+        (
+          export HOME="$WRAPPER_ROOT/home"
+          export PNPM_HOME="$WRAPPER_ROOT/custom-pnpm-home"
+          store_path="$($out/bin/pnpm store path)"
+          test "$store_path" = "$PNPM_HOME/store/v${lib.versions.major version}"
+          test -d "$PNPM_HOME"
+          test -d "$PNPM_HOME$WRAPPER_GLOBAL_SUFFIX"
+        )
+        (
+          export HOME="/homeless-shelter"
+          unset PNPM_HOME XDG_DATA_HOME
+          store_path="$($out/bin/pnpm store path)"
+          case "$store_path" in
+            /homeless-shelter/*)
+              echo "pnpm wrapper should not create state below /homeless-shelter" >&2
+              exit 1
+              ;;
+          esac
+        )
 
         echo "Checking PNPM_HOME setup hook..."
         SETUP_ROOT=$(mktemp -d)

--- a/packages/pnpm/pnpm-default-env.sh
+++ b/packages/pnpm/pnpm-default-env.sh
@@ -1,0 +1,63 @@
+# Shared runtime defaults for the standalone pnpm package.
+# This file is sourced by the pnpm wrapper and by the Nix setup hook.
+
+pnpm_default_home() {
+	if [ -n "${XDG_DATA_HOME:-}" ]; then
+		printf '%s\n' "${XDG_DATA_HOME}/pnpm"
+		return 0
+	fi
+
+	if [ -z "${HOME:-}" ] || [ "${HOME}" = /homeless-shelter ]; then
+		return 1
+	fi
+
+	case "$(uname -s)" in
+	Darwin)
+		printf '%s\n' "${HOME}/Library/pnpm"
+		;;
+	*)
+		printf '%s\n' "${HOME}/.local/share/pnpm"
+		;;
+	esac
+}
+
+pnpm_global_bin_dir() {
+	if [ -z "${PNPM_HOME:-}" ]; then
+		return 1
+	fi
+
+	if [ "@PNPM_USE_RUNTIME_COMMAND@" = "1" ]; then
+		printf '%s\n' "${PNPM_HOME}/bin"
+	else
+		printf '%s\n' "${PNPM_HOME}"
+	fi
+}
+
+pnpm_set_mutable_state_defaults() {
+	if [ -z "${PNPM_HOME:-}" ]; then
+		PNPM_HOME="$(pnpm_default_home || true)"
+		if [ -n "${PNPM_HOME:-}" ]; then
+			export PNPM_HOME
+		fi
+	fi
+
+	if [ -n "${PNPM_HOME:-}" ]; then
+		mkdir -p "${PNPM_HOME}" "$(pnpm_global_bin_dir)" 2>/dev/null || true
+	fi
+}
+
+pnpm_prepend_global_bin() {
+	local pnpm_global_bin
+
+	pnpm_global_bin="$(pnpm_global_bin_dir || true)"
+	if [ -z "${pnpm_global_bin:-}" ]; then
+		return 0
+	fi
+
+	case ":${PATH:-}:" in
+	*":${pnpm_global_bin}:"*) ;;
+	*) export PATH="${pnpm_global_bin}:${PATH:-}" ;;
+	esac
+}
+
+pnpm_set_mutable_state_defaults

--- a/readme.md
+++ b/readme.md
@@ -442,11 +442,13 @@ CLI for Pina, a performant Solana smart contract framework. Built from source us
 
 ### pnpm
 
-Standalone pnpm binary with no Node.js dependency. Downloaded directly from GitHub releases. `pnpm` tracks the latest release, while `pnpm-11` and `pnpm-10` are explicit versioned tracks. `pnpm-standalone` is kept as a compatibility alias for the latest track. Includes `pnpm-activate-env` to read `useNodeVersion` from `pnpm-workspace.yaml`, install that Node.js version with the appropriate pnpm runtime/env command, and emit PATH export commands.
+Standalone pnpm binary with no Node.js dependency. Downloaded directly from GitHub releases. `pnpm` tracks the latest release, while `pnpm-11` and `pnpm-10` are explicit versioned tracks. `pnpm-standalone` is kept as a compatibility alias for the latest track. The wrapper sets mutable state defaults for PNPM-managed Node and package stores without writing to the Nix store. Includes `pnpm-activate-env` to read `useNodeVersion` from `pnpm-workspace.yaml`, install that Node.js version with the appropriate pnpm runtime/env command, and emit PATH export commands.
 
 - **Binary:** `pnpm`, `pnpm-activate-env`
 - **Packages:** `pnpm`, `pnpm-11`, `pnpm-10`, `pnpm-standalone`
 - **Activate workspace Node version:** `eval "$(pnpm-activate-env)"`
+- **Mutable state defaults:** sets `PNPM_HOME` when unset (`$XDG_DATA_HOME/pnpm`, `~/Library/pnpm` on macOS, or `~/.local/share/pnpm` on Linux)
+- **Store location:** PNPM stores packages and managed Node runtimes under `PNPM_HOME` (for example, `PNPM_HOME/store` and `PNPM_HOME/bin` on v11)
 - **Runtime support:** v11 uses `pnpm runtime set node`; v10 uses `pnpm env add --global`
 - **License:** MIT
 - **Source:** <https://github.com/pnpm/pnpm>

--- a/scripts/update
+++ b/scripts/update
@@ -1319,7 +1319,12 @@ def update-secretspec [repo_root: string, dry_run: bool] {
   let owner = "ifiokjr"
   let repo = "secretspec"
   let branch = "feat/provider-secret-locations"
-  let rev = (github-head-rev $owner $repo $branch)
+  let rev = (try {
+    github-head-rev $owner $repo $branch
+  } catch {|err|
+    log-warn $"secretspec lookup failed, using current version \(($err.msg)\)"
+    return false
+  })
   let source_url = $"https://github.com/($owner)/($repo)/archive/refs/heads/($branch).tar.gz"
   let file = $"($repo_root)/packages/secretspec/package.nix"
   let content = (open $file --raw)


### PR DESCRIPTION
Configure standalone pnpm wrappers to default mutable PNPM state outside the Nix store.\n\nChanges:\n- Set PNPM_HOME when unset using XDG_DATA_HOME, ~/Library/pnpm on macOS, or ~/.local/share/pnpm on Linux\n- Prepend the PNPM global bin dir for pnpm invocations so PNPM-managed Node installs work\n- Reuse the same defaults in the Nix setup hook\n- Add install-check fixture coverage for wrapper defaults, XDG overrides, custom PNPM_HOME, and setup-hook behavior\n- Document PNPM_HOME/store behavior\n\nValidation:\n- dprint fmt\n- nix run .#mdt -- update\n- nix run .#mdt -- check\n- nix flake check --no-build\n- nix build .#pnpm .#pnpm-10 .#pnpm-11\n- isolated fixture: pnpm install with temp HOME and pnpm runtime set node 20.11.1 --global