### PR TITLE
feat(zed): add stable and preview packages

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -64,6 +64,8 @@
         steam = final.callPackage ./packages/steam/package.nix { };
         surfpool = final.callPackage ./packages/surfpool/package.nix { };
         wait-for-them = final.callPackage ./packages/wait-for-them/package.nix { };
+        zed = final.callPackage ./packages/zed/package.nix { };
+        zed-preview = final.callPackage ./packages/zed-preview/package.nix { };
         zoom = final.callPackage ./packages/zoom/package.nix { };
       };
     }
@@ -127,6 +129,8 @@
           steam = pkgs.callPackage ./packages/steam/package.nix { };
           surfpool = pkgs.callPackage ./packages/surfpool/package.nix { };
           wait-for-them = pkgs.callPackage ./packages/wait-for-them/package.nix { };
+          zed = pkgs.callPackage ./packages/zed/package.nix { };
+          zed-preview = pkgs.callPackage ./packages/zed-preview/package.nix { };
           zoom = pkgs.callPackage ./packages/zoom/package.nix { };
         };
 

--- a/packages/zed-preview/package.nix
+++ b/packages/zed-preview/package.nix
@@ -1,0 +1,28 @@
+{
+  stdenv,
+  fetchurl,
+  lib,
+  undmg,
+  makeWrapper,
+}:
+
+let
+  version = "1.7.1-pre";
+in
+import ../zed/package.nix {
+  inherit
+    stdenv
+    fetchurl
+    lib
+    undmg
+    makeWrapper
+    ;
+  channel = "preview";
+  overrideVersion = version;
+  zedHashes = {
+    "aarch64-darwin" = "sha256-bbz0nDPMWtm6Ft/0vlA3g3tQn7cN7hEz2Wgz82iiAc4=";
+    "x86_64-darwin" = "sha256-36bxhO46LOCyYtCELQtJHRkaWdFOdhC2HZh3OxHGN78=";
+    "aarch64-linux" = "sha256-DaOUKx55nQqNSgiDJjAWaUPCq3s1ONtAdJnFNPQer7w=";
+    "x86_64-linux" = "sha256-lp8fBLT0o7Bw+hctvnmgHeTKvq/4xYfkI0uMpTJNUcA=";
+  };
+}

--- a/packages/zed/package.nix
+++ b/packages/zed/package.nix
@@ -1,0 +1,103 @@
+{
+  stdenv,
+  fetchurl,
+  lib,
+  undmg,
+  makeWrapper,
+  channel ? "stable",
+  overrideVersion ? null,
+  zedHashes ? {
+    "aarch64-darwin" = "sha256-fbZUpnidVeg+j9LV0r5qqoM+X7DepwMVAOgy59QFnQg=";
+    "x86_64-darwin" = "sha256-5pEOEpdeauSThCwEOrOTeyiPlweuTBNd5soGiJnR4lM=";
+    "aarch64-linux" = "sha256-u3Nzwrq3uAklEDCoaz01CzHfQPajrlRU//Cvo61hh34=";
+    "x86_64-linux" = "sha256-D9YYdS5CgvpGl3hjr2t83BkK4tt+CzOur4NUOOBTjbU=";
+  },
+}:
+
+let
+  pname = if channel == "preview" then "zed-preview" else "zed";
+  version = "1.6.3";
+  resolvedVersion = if overrideVersion == null then version else overrideVersion;
+  tag = "v${resolvedVersion}";
+  arch = if stdenv.hostPlatform.isAarch64 then "aarch64" else "x86_64";
+  asset = if stdenv.hostPlatform.isDarwin then "Zed-${arch}.dmg" else "zed-linux-${arch}.tar.gz";
+  platformKey = if stdenv.hostPlatform.isDarwin then "${arch}-darwin" else "${arch}-linux";
+  appName = if channel == "preview" then "Zed Preview" else "Zed";
+in
+stdenv.mkDerivation {
+  inherit pname;
+  version = resolvedVersion;
+
+  src = fetchurl {
+    url = "https://github.com/zed-industries/zed/releases/download/${tag}/${asset}";
+    hash = zedHashes.${platformKey} or lib.fakeHash;
+  };
+
+  nativeBuildInputs =
+    lib.optionals stdenv.hostPlatform.isDarwin [ undmg ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [ makeWrapper ];
+
+  sourceRoot = ".";
+  dontUnpack = stdenv.hostPlatform.isDarwin;
+  dontPatch = true;
+  dontConfigure = true;
+  dontBuild = true;
+  dontFixup = true;
+
+  installPhase = ''
+    runHook preInstall
+  ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    mkdir -p $out/Applications $out/bin
+
+    mountpoint=$TMPDIR/zed-dmg
+    mkdir -p "$mountpoint"
+    /usr/bin/hdiutil attach -nobrowse -readonly -mountpoint "$mountpoint" "$src"
+
+    app=$(find "$mountpoint" -maxdepth 2 -name "*.app" -type d | head -n 1)
+    cp -R "$app" $out/Applications/
+    /usr/bin/hdiutil detach "$mountpoint"
+
+    installed_app="$out/Applications/$(basename "$app")"
+    if [ -x "$installed_app/Contents/MacOS/cli" ]; then
+      ln -s "$installed_app/Contents/MacOS/cli" $out/bin/${pname}
+    elif [ -x "$installed_app/Contents/MacOS/${appName}" ]; then
+      ln -s "$installed_app/Contents/MacOS/${appName}" $out/bin/${pname}
+    fi
+  ''
+  + lib.optionalString stdenv.hostPlatform.isLinux ''
+    mkdir -p $out
+    cp -R zed.app/* $out/
+
+    if [ -x $out/bin/zed ]; then
+      mv $out/bin/zed $out/bin/.zed-unwrapped
+      makeWrapper $out/bin/.zed-unwrapped $out/bin/${pname} \
+        --prefix LD_LIBRARY_PATH : $out/lib
+    fi
+
+    if [ -f $out/share/applications/dev.zed.Zed.desktop ]; then
+      substituteInPlace $out/share/applications/dev.zed.Zed.desktop \
+        --replace-fail "Exec=zed" "Exec=${pname}" \
+        --replace-fail "Name=Zed" "Name=${appName}"
+    fi
+  ''
+  + ''
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "High-performance, multiplayer code editor from the creators of Atom and Tree-sitter";
+    homepage = "https://zed.dev";
+    changelog = "https://github.com/zed-industries/zed/releases/tag/${tag}";
+    license = licenses.gpl3Only;
+    mainProgram = pname;
+    maintainers = [ ];
+    platforms = [
+      "aarch64-darwin"
+      "x86_64-darwin"
+      "aarch64-linux"
+      "x86_64-linux"
+    ];
+    sourceProvenance = [ sourceTypes.binaryNativeCode ];
+  };
+}

--- a/scripts/update
+++ b/scripts/update
@@ -3,7 +3,7 @@
 #
 # The script covers:
 # - Flake inputs (nix flake update → flake.lock)
-# - Versioned GitHub release packages (agave, codex-cli, deno, godot, kani, mdt, monochange, ollama, solana-verify, surfpool, etc.)
+# - Versioned GitHub release packages (agave, codex-cli, deno, godot, kani, mdt, monochange, ollama, solana-verify, surfpool, zed, etc.)
 # - Homebrew-cask versioned packages (gpg-suite, nordvpn, zoom)
 # - Rolling URL packages (steam)
 # - Rust packages built from source (cargo-clean-all, cargo-interactive-update, dylint, knope, pina, sbpf-linker)
@@ -522,6 +522,22 @@ def derive-cargo-hash [repo_root: string, package: string] {
 }
 
 # Generic update strategies
+
+def github-latest-prerelease-tag [owner: string, repo: string] {
+  let releases = (github-api-get $"https://api.github.com/repos/($owner)/($repo)/releases?per_page=100")
+  let found = (
+    $releases
+    | where {|release| $release.prerelease }
+    | get -o 0.tag_name
+    | default ""
+  )
+
+  if ($found | is-empty) {
+    fail $"No prerelease found for ($owner)/($repo)"
+  }
+
+  $found
+}
 
 def update-versioned-keyed-hashes [
   name: string,
@@ -1488,6 +1504,28 @@ def update-prebuilt-package [
   trigger-prebuilt-build $package $latest_version $dry_run
 }
 
+def update-zed-release [packages_dir: string, package_name: string, tag: string, dry_run: bool] {
+  let latest_version = ($tag | str replace --regex '^v' '')
+  let file = $"($packages_dir)/($package_name)/package.nix"
+  let entries = [
+    { key: "aarch64-darwin", url: $"https://github.com/zed-industries/zed/releases/download/($tag)/Zed-aarch64.dmg" }
+    { key: "x86_64-darwin", url: $"https://github.com/zed-industries/zed/releases/download/($tag)/Zed-x86_64.dmg" }
+    { key: "aarch64-linux", url: $"https://github.com/zed-industries/zed/releases/download/($tag)/zed-linux-aarch64.tar.gz" }
+    { key: "x86_64-linux", url: $"https://github.com/zed-industries/zed/releases/download/($tag)/zed-linux-x86_64.tar.gz" }
+  ]
+  update-versioned-keyed-hashes $package_name $file $latest_version $entries $dry_run
+}
+
+def update-zed [packages_dir: string, dry_run: bool] {
+  let tag = (github-latest-stable-tag "zed-industries" "zed")
+  update-zed-release $packages_dir "zed" $tag $dry_run
+}
+
+def update-zed-preview [packages_dir: string, dry_run: bool] {
+  let tag = (github-latest-prerelease-tag "zed-industries" "zed")
+  update-zed-release $packages_dir "zed-preview" $tag $dry_run
+}
+
 def update-dylint [packages_dir: string, dry_run: bool] {
   let tag = (github-latest-tag "trailofbits" "dylint")
   let latest_version = ($tag | str replace --regex '^v' '')
@@ -1672,6 +1710,8 @@ def main [
     { name: "steam", run: {|| update-rolling-steam $packages_dir $dry_run } }
     { name: "surfpool", run: {|| update-surfpool $packages_dir $dry_run } }
     { name: "wait-for-them", run: {|| update-rust-wait-for-them $root $packages_dir $dry_run } }
+    { name: "zed", run: {|| update-zed $packages_dir $dry_run } }
+    { name: "zed-preview", run: {|| update-zed-preview $packages_dir $dry_run } }
     { name: "zoom", run: {|| update-zoom $packages_dir $dry_run } }
   ]
 


### PR DESCRIPTION
## Summary
- add binary packages for Zed stable and preview releases
- expose `zed` and `zed-preview` from the flake and overlay
- update `scripts/update` to refresh Zed stable/prerelease versions and hashes

## Checks
- `nix build .#zed --no-link`
- `nix build .#zed-preview --no-link`
- `nix flake check --no-build`
- `dprint fmt`
